### PR TITLE
Environment handling

### DIFF
--- a/knime.yml
+++ b/knime.yml
@@ -4,10 +4,14 @@ author: Redfield AB
 vendor: Redfield AB
 description: "Redfield BERT Nodes"
 long_description: |
-  The extension provides the nodes that allow to use Google BERT Python libarary without coding.
-  Currently only classification for the texts is implemented.
+  This extension provides nodes that make the functionality of Google's BERT library available in the KNIME Analytics Platform.
+  Currently, the extension is allows the training of text classification models as well as creating embeddings for texts.
   This extension is built on top of the TensorFlow 2 Python package. 
   It is also possible to execute BERT on GPU (nVidia CUDA-based).
+  
+  NOTE: The installation of this extension can fail on Windows if the installation folder of your Analytics Platform has a long path.
+  This is due to Windows' long path limitations. You can circumvent this problem by enabling long path support as outlined here: 
+  https://docs.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=registry
 env_yml_path: 
   win-64: se.redfield.bert/config/bert_win_cpu.yml
   linux-64: se.redfield.bert/config/bert_linux_cpu.yml

--- a/knime.yml
+++ b/knime.yml
@@ -8,7 +8,10 @@ long_description: |
   Currently only classification for the texts is implemented.
   This extension is built on top of the TensorFlow 2 Python package. 
   It is also possible to execute BERT on GPU (nVidia CUDA-based).
-env_yml_path: se.redfield.bert/config/bert_cpu.yml
+env_yml_path: 
+  win-64: se.redfield.bert/config/bert_win_cpu.yml
+  linux-64: se.redfield.bert/config/bert_linux_cpu.yml
+  osx-64: se.redfield.bert/config/bert_osx_cpu.yml
 version: 1.0.0
 copyright: "Copyright (c) 2020 Redfield AB"
 license_file: LICENSE.txt

--- a/knime.yml
+++ b/knime.yml
@@ -1,0 +1,19 @@
+group_id: se.redfield
+name: bert
+author: Redfield AB
+vendor: Redfield AB
+description: "Redfield BERT Nodes"
+long_description: |
+  The extension provides the nodes that allow to use Google BERT Python libarary without coding.
+  Currently only classification for the texts is implemented.
+  This extension is built on top of the TensorFlow 2 Python package. 
+  It is also possible to execute BERT on GPU (nVidia CUDA-based).
+env_yml_path: se.redfield.bert/config/bert_cpu.yml
+version: 1.0.0
+copyright: "Copyright (c) 2020 Redfield AB"
+license_file: LICENSE.txt
+java_bundles:
+  - se.redfield.bert
+feature_dependencies:
+  - org.knime.features.ext.textprocessing
+  - org.knime.features.python2

--- a/se.redfield.bert/META-INF/MANIFEST.MF
+++ b/se.redfield.bert/META-INF/MANIFEST.MF
@@ -18,7 +18,8 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.13.0,4.0.0)",
  org.knime.dl.python;bundle-version="[4.6.0,5.0.0)",
  org.knime.ext.textprocessing;bundle-version="[4.6.0,5.0.0)",
  org.knime.conda;bundle-version="[4.6.0,5.0.0)",
- com.google.gson;bundle-version="2.8.6"
+ org.knime.python3.scripting.nodes;bundle-version="[4.6.0,5.0.0)",
+ com.google.gson;bundle-version="[2.8.6,3.0.0)"
 Bundle-ActivationPolicy: lazy
 Export-Package: se.redfield.bert
 Automatic-Module-Name: se.redfield.bert

--- a/se.redfield.bert/config/bert_cpu.yml
+++ b/se.redfield.bert/config/bert_cpu.yml
@@ -1,0 +1,17 @@
+name: py39_bert_cpu # Name of the created environment
+channels:                # Repositories to search for packages
+- conda-forge
+dependencies:            # List of packages that should be installed
+- python=3.9             # Python
+- py4j                   # used for KNIME <-> Python communication
+- nomkl                  # Prevents the use of Intel's MKL
+- pandas                 # Table data structures
+- numpy                  # N-dimensional arrays
+- pyarrow=7.0            # Arrow serialization
+- pip
+- pip:
+  - tensorflow-cpu
+  - tensorflow-hub
+  - transformers
+  - bert-for-tf2
+

--- a/se.redfield.bert/config/bert_linux_cpu.yml
+++ b/se.redfield.bert/config/bert_linux_cpu.yml
@@ -7,11 +7,12 @@ dependencies:            # List of packages that should be installed
 - nomkl                  # Prevents the use of Intel's MKL
 - pandas                 # Table data structures
 - numpy                  # N-dimensional arrays
-- pyarrow=7.0            # Arrow serialization
+- pyarrow<8.0            # Arrow serialization
+- protobuf<4.0           # Versions larger than 4.0 are incompatible with tensorflow-hub and bert-for-tf2
+- tensorflow-cpu=2.8.1
+- tensorflow-hub=0.12.0
+- transformers=4.6.1
 - pip
-- tensorflow-cpu
-- tensorflow-hub
-- transformers
 - pip:
-  - bert-for-tf2
+  - bert-for-tf2==0.14.9
 

--- a/se.redfield.bert/config/bert_linux_cpu.yml
+++ b/se.redfield.bert/config/bert_linux_cpu.yml
@@ -1,0 +1,17 @@
+name: py39_bert_cpu # Name of the created environment
+channels:                # Repositories to search for packages
+- conda-forge
+dependencies:            # List of packages that should be installed
+- python=3.9             # Python
+- py4j                   # used for KNIME <-> Python communication
+- nomkl                  # Prevents the use of Intel's MKL
+- pandas                 # Table data structures
+- numpy                  # N-dimensional arrays
+- pyarrow=7.0            # Arrow serialization
+- pip
+- tensorflow-cpu
+- tensorflow-hub
+- transformers
+- pip:
+  - bert-for-tf2
+

--- a/se.redfield.bert/config/bert_linux_gpu.yml
+++ b/se.redfield.bert/config/bert_linux_gpu.yml
@@ -1,0 +1,18 @@
+name: py39_bert_gpu # Name of the created environment
+channels:                # Repositories to search for packages
+- conda-forge
+dependencies:            # List of packages that should be installed
+- python=3.9             # Python
+- py4j                   # used for KNIME <-> Python communication
+- nomkl                  # Prevents the use of Intel's MKL
+- pandas                 # Table data structures
+- numpy                  # N-dimensional arrays
+- pyarrow<8.0            # Arrow serialization
+- protobuf<4.0           # Versions larger than 4.0 are incompatible with tensorflow-hub and bert-for-tf2
+- tensorflow=2.8.1
+- tensorflow-hub=0.12.0
+- transformers=4.6.1
+- pip
+- pip:
+  - bert-for-tf2==0.14.9
+

--- a/se.redfield.bert/config/bert_osx_cpu.yml
+++ b/se.redfield.bert/config/bert_osx_cpu.yml
@@ -9,9 +9,9 @@ dependencies:            # List of packages that should be installed
 - numpy                  # N-dimensional arrays
 - pyarrow=7.0            # Arrow serialization
 - pip
+- tensorflow
+- tensorflow-hub
+- transformers
 - pip:
-  - tensorflow-cpu
-  - tensorflow-hub
-  - transformers
   - bert-for-tf2
 

--- a/se.redfield.bert/config/bert_osx_cpu.yml
+++ b/se.redfield.bert/config/bert_osx_cpu.yml
@@ -7,11 +7,12 @@ dependencies:            # List of packages that should be installed
 - nomkl                  # Prevents the use of Intel's MKL
 - pandas                 # Table data structures
 - numpy                  # N-dimensional arrays
-- pyarrow=7.0            # Arrow serialization
+- pyarrow<8.0            # Arrow serialization
+- protobuf<4.0           # Versions larger than 4.0 are incompatible with tensorflow-hub and bert-for-tf2
+- tensorflow=2.8.1
+- tensorflow-hub=0.12.0
+- transformers=4.6.1
 - pip
-- tensorflow
-- tensorflow-hub
-- transformers
 - pip:
-  - bert-for-tf2
+  - bert-for-tf2==0.14.9
 

--- a/se.redfield.bert/config/bert_win_cpu.yml
+++ b/se.redfield.bert/config/bert_win_cpu.yml
@@ -7,11 +7,12 @@ dependencies:            # List of packages that should be installed
 - nomkl                  # Prevents the use of Intel's MKL
 - pandas                 # Table data structures
 - numpy                  # N-dimensional arrays
-- pyarrow=7.0            # Arrow serialization
+- pyarrow<8.0            # Arrow serialization
+- protobuf<4.0           # Versions larger than 4.0 are incompatible with tensorflow-hub and bert-for-tf2
 - pip
 - pip:
-  - tensorflow
-  - tensorflow-hub
-  - transformers
-  - bert-for-tf2
+  - tensorflow==2.9.1
+  - tensorflow-hub==0.12.0
+  - transformers==4.21.1
+  - bert-for-tf2==0.14.9
 

--- a/se.redfield.bert/config/bert_win_cpu.yml
+++ b/se.redfield.bert/config/bert_win_cpu.yml
@@ -1,0 +1,17 @@
+name: py39_bert_cpu # Name of the created environment
+channels:                # Repositories to search for packages
+- conda-forge
+dependencies:            # List of packages that should be installed
+- python=3.9             # Python
+- py4j                   # used for KNIME <-> Python communication
+- nomkl                  # Prevents the use of Intel's MKL
+- pandas                 # Table data structures
+- numpy                  # N-dimensional arrays
+- pyarrow=7.0            # Arrow serialization
+- pip
+- pip:
+  - tensorflow
+  - tensorflow-hub
+  - transformers
+  - bert-for-tf2
+

--- a/se.redfield.bert/config/bert_win_gpu.yml
+++ b/se.redfield.bert/config/bert_win_gpu.yml
@@ -1,0 +1,20 @@
+name: py39_bert_gpu # Name of the created environment
+channels:                # Repositories to search for packages
+- conda-forge
+dependencies:            # List of packages that should be installed
+- python=3.9             # Python
+- py4j                   # used for KNIME <-> Python communication
+- nomkl                  # Prevents the use of Intel's MKL
+- pandas                 # Table data structures
+- numpy                  # N-dimensional arrays
+- pyarrow<8.0            # Arrow serialization
+- protobuf<4.0           # Versions larger than 4.0 are incompatible with tensorflow-hub and bert-for-tf2
+- cudatoolkit=11.2
+- cudnn=8.1.0
+- pip
+- pip:
+  - tensorflow==2.9.1
+  - tensorflow-hub==0.12.0
+  - transformers==4.21.1
+  - bert-for-tf2==0.14.9
+

--- a/se.redfield.bert/plugin.xml
+++ b/se.redfield.bert/plugin.xml
@@ -75,5 +75,20 @@
                path="/community">
          </category>
       </extension>
+      <extension
+            point="org.eclipse.core.runtime.preferences">
+         <initializer
+               class="se.redfield.bert.prefs.BertPreferenceInitializer">
+         </initializer>
+      </extension>
+      <extension
+            point="org.eclipse.ui.preferencePages">
+         <page
+               category="org.knime.workbench.ui.preferences"
+               class="se.redfield.bert.prefs.BertPreferencePage"
+               id="se.redfield.bert.prefs.BertPreferencePage"
+               name="Redfield BERT Nodes">
+         </page>
+      </extension>
    
 </plugin>

--- a/se.redfield.bert/src/se/redfield/bert/prefs/BertPreferenceInitializer.java
+++ b/se.redfield.bert/src/se/redfield/bert/prefs/BertPreferenceInitializer.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2021 Redfield AB.
+*/
+package se.redfield.bert.prefs;
+
+import java.io.IOException;
+
+import org.eclipse.core.runtime.preferences.AbstractPreferenceInitializer;
+import org.knime.conda.Conda;
+import org.knime.conda.prefs.CondaPreferences;
+import org.knime.core.node.NodeLogger;
+import org.knime.python2.config.CondaEnvironmentsConfig;
+import org.knime.python2.config.ManualEnvironmentsConfig;
+import org.knime.python2.config.PythonConfig;
+import org.knime.python2.config.PythonEnvironmentType;
+import org.knime.python2.config.PythonEnvironmentTypeConfig;
+import org.knime.python2.prefs.PythonPreferences;
+
+/**
+ * Preferences initializer.
+ * 
+ * @author Alexander Bondaletov
+ *
+ */
+public class BertPreferenceInitializer extends AbstractPreferenceInitializer {
+	@SuppressWarnings("unused")
+	private static final NodeLogger LOGGER = NodeLogger.getLogger(BertPreferenceInitializer.class);
+
+	/**
+	 * The cache directory setting key
+	 */
+	static final String PREF_CACHE_DIR = "redfield.bert.cachedir";
+
+	@Override
+	public void initializeDefaultPreferences() {
+		saveToDefault(//
+				BertPreferences.createBundledEnvConfig(), //
+				BertPreferences.createEnvTypeConfig(), //
+				BertPreferences.createCondaEnvConfig(), //
+				BertPreferences.createManualEnvConfig(), //
+				BertPreferences.createCacheDirConfig()//
+		);
+	}
+
+	private static void saveToDefault(final PythonConfig... configs) {
+		for (var config : configs) {
+			config.saveConfigTo(BertPreferences.DEFAULT);
+		}
+	}
+
+	static PythonEnvironmentTypeConfig getDefaultPythonEnvironmentTypeConfig() {
+		return new PythonEnvironmentTypeConfig(PythonPreferences.getEnvironmentTypePreference());
+	}
+
+	static CondaEnvironmentsConfig getDefaultCondaEnvironmentsConfig() {
+		return (CondaEnvironmentsConfig) PythonPreferences.getPythonEnvironmentsConfig(PythonEnvironmentType.CONDA);
+	}
+
+	static ManualEnvironmentsConfig getDefaultManualEnvironmentsConfig() {
+		return (ManualEnvironmentsConfig) PythonPreferences.getPythonEnvironmentsConfig(PythonEnvironmentType.MANUAL);
+	}
+
+	static boolean isCondaConfigured() {
+		try {
+			final var condaDir = CondaPreferences.getCondaInstallationDirectory();
+			final var conda = new Conda(condaDir);
+			conda.testInstallation();
+			return true;
+		} catch (IOException ex) { // NOSONAR: we handle the exception by returning false, no need to rethrow
+			return false;
+		}
+	}
+}

--- a/se.redfield.bert/src/se/redfield/bert/prefs/BertPreferenceInitializer.java
+++ b/se.redfield.bert/src/se/redfield/bert/prefs/BertPreferenceInitializer.java
@@ -19,8 +19,7 @@ import org.knime.python2.prefs.PythonPreferences;
 /**
  * Preferences initializer.
  * 
- * @author Alexander Bondaletov
- *
+ * @author Adrian Nembach, KNIME GmbH, Konstanz, Germany
  */
 public class BertPreferenceInitializer extends AbstractPreferenceInitializer {
 	@SuppressWarnings("unused")

--- a/se.redfield.bert/src/se/redfield/bert/prefs/BertPreferencePage.java
+++ b/se.redfield.bert/src/se/redfield/bert/prefs/BertPreferencePage.java
@@ -5,7 +5,9 @@ package se.redfield.bert.prefs;
 
 import java.util.List;
 
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.swt.widgets.Composite;
+import org.knime.core.node.KNIMEConstants;
 import org.knime.core.util.Version;
 import org.knime.python2.PythonModuleSpec;
 import org.knime.python2.config.PythonConfig;
@@ -64,9 +66,23 @@ public final class BertPreferencePage extends AbstractPythonPreferencePage {
 	}
 
 	private static String getEnvPath(final String tag) {
-		return PythonSourceDirectoryLocator.getPathFor(BertPreferencePage.class, "config/bert_" + tag + ".yml")//
+		return PythonSourceDirectoryLocator
+				.getPathFor(BertPreferencePage.class, String.format("config/bert_%s_%s.yml", getPlatformTag(), tag))//
 				.toAbsolutePath()//
 				.toString();
+	}
+	
+	private static String getPlatformTag() {
+		final var os = Platform.getOS();
+		if (Platform.OS_WIN32.equals(os)) {
+			return "win";
+		} else if (Platform.OS_LINUX.equals(os)) {
+			return "linux";
+		} else if (Platform.OS_MACOSX.equals(os)) {
+			return "osx";
+		} else {
+			throw new IllegalStateException("Unsupported platform: " + os);
+		}
 	}
 
 	@Override

--- a/se.redfield.bert/src/se/redfield/bert/prefs/BertPreferencePage.java
+++ b/se.redfield.bert/src/se/redfield/bert/prefs/BertPreferencePage.java
@@ -20,8 +20,7 @@ import se.redfield.bert.prefs.MultiOptionEnvironmentCreator.CondaEnvironmentCrea
 /**
  * The preference page.
  * 
- * @author Alexander Bondaletov
- *
+ * @author Adrian Nembach, KNIME GmbH, Konstanz, Germany
  */
 public final class BertPreferencePage extends AbstractPythonPreferencePage {
 

--- a/se.redfield.bert/src/se/redfield/bert/prefs/BertPreferencePage.java
+++ b/se.redfield.bert/src/se/redfield/bert/prefs/BertPreferencePage.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2021 Redfield AB.
+*/
+package se.redfield.bert.prefs;
+
+import java.util.List;
+
+import org.eclipse.swt.widgets.Composite;
+import org.knime.core.util.Version;
+import org.knime.python2.PythonModuleSpec;
+import org.knime.python2.config.PythonConfig;
+import org.knime.python2.prefs.AbstractPythonPreferencePage;
+import org.knime.python3.PythonSourceDirectoryLocator;
+import org.knime.python3.scripting.nodes.prefs.BundledCondaEnvironmentConfig;
+
+import se.redfield.bert.prefs.MultiOptionEnvironmentCreator.CondaEnvironmentCreationOption;
+
+/**
+ * The preference page.
+ * 
+ * @author Alexander Bondaletov
+ *
+ */
+public final class BertPreferencePage extends AbstractPythonPreferencePage {
+
+	private static final String FEATURE_NAME = "Redfield BERT Nodes";
+
+	// TODO add GPU
+	private final MultiOptionEnvironmentCreator m_condaEnvironmentCreator = new MultiOptionEnvironmentCreator(
+			FEATURE_NAME, "redfield_bert", new CondaEnvironmentCreationOption("CPU", true, getEnvPath("cpu")));
+
+	private final PythonEnvironmentSelectionConfig m_pyEnvSelectConfig = new PythonEnvironmentSelectionConfig(
+			BertPreferenceInitializer.getDefaultPythonEnvironmentTypeConfig(),
+			BertPreferenceInitializer.getDefaultCondaEnvironmentsConfig(),
+			BertPreferenceInitializer.getDefaultManualEnvironmentsConfig(),
+			new BundledCondaEnvironmentConfig(BertPreferences.BUNDLED_ENV_ID));
+
+	private PythonEnvironmentSelectionPanel m_pyEnvSelectPanel;
+
+	/**
+	 * Creates new instance.
+	 */
+	public BertPreferencePage() {
+		super(BertPreferences.CURRENT, BertPreferences.DEFAULT);
+	}
+
+	@Override
+	protected void populatePageBody(Composite container, List<PythonConfig> configs) {
+		configs.add(m_pyEnvSelectConfig);
+		var configObserver = new BundledEnvironmentConfigsObserver(m_pyEnvSelectConfig, m_condaEnvironmentCreator,
+				FEATURE_NAME, List.of(//
+						// TODO double check requirements
+						new PythonModuleSpec("py4j"), //
+						new PythonModuleSpec("pyarrow", new Version(6, 0, 0), true), //
+						new PythonModuleSpec("pandas"),
+						new PythonModuleSpec("transformers"),
+						new PythonModuleSpec("tensorflow"),
+						new PythonModuleSpec("bert.tokenization"),
+						new PythonModuleSpec("tensorflow_hub"))//
+		);
+		m_pyEnvSelectPanel = new PythonEnvironmentSelectionPanel(container, m_pyEnvSelectConfig,
+				m_condaEnvironmentCreator, configObserver);
+
+	}
+
+	private static String getEnvPath(final String tag) {
+		return PythonSourceDirectoryLocator.getPathFor(BertPreferencePage.class, "config/bert_" + tag + ".yml")//
+				.toAbsolutePath()//
+				.toString();
+	}
+
+	@Override
+	protected void reflectLoadedConfigurations() {
+		String warning = m_pyEnvSelectPanel.reflectLoadedConfigurations();
+		setMessage(FEATURE_NAME, NONE);
+		updateDisplayMinSize();
+		if (warning != null) {
+			setMessage(warning, WARNING);
+		}
+	}
+
+	@Override
+	protected void setupHooks() {
+		m_pyEnvSelectConfig.getEnvironmentTypeConfig().getEnvironmentType()
+				.addChangeListener(e -> setMessage(FEATURE_NAME, NONE));
+		m_pyEnvSelectPanel.setupHooksAfterInitialization(this::updateDisplayMinSize);
+	}
+}

--- a/se.redfield.bert/src/se/redfield/bert/prefs/BertPreferences.java
+++ b/se.redfield.bert/src/se/redfield/bert/prefs/BertPreferences.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2021 Redfield AB.
+*/
+package se.redfield.bert.prefs;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.function.Supplier;
+
+import org.eclipse.core.runtime.preferences.DefaultScope;
+import org.eclipse.core.runtime.preferences.InstanceScope;
+import org.knime.core.node.NodeLogger;
+import org.knime.python2.PythonCommand;
+import org.knime.python2.config.CondaEnvironmentsConfig;
+import org.knime.python2.config.ManualEnvironmentsConfig;
+import org.knime.python2.config.PythonConfig;
+import org.knime.python2.config.PythonConfigStorage;
+import org.knime.python2.config.PythonEnvironmentType;
+import org.knime.python2.config.PythonEnvironmentTypeConfig;
+import org.knime.python2.config.PythonEnvironmentsConfig;
+import org.knime.python2.prefs.PreferenceStorage;
+import org.knime.python2.prefs.PreferenceWrappingConfigStorage;
+import org.knime.python3.scripting.nodes.prefs.BundledCondaEnvironmentConfig;
+
+/**
+ * Convenience front-end of the BERT preferences.
+ * 
+ * @author Adrian Nembach, KNIME GmbH, Konstanz, Germany
+ */
+public final class BertPreferences {
+
+	private static final String PLUGIN_ID = "se.redfield.bert";
+
+	private static final PreferenceStorage DEFAULT_SCOPE_PREFS = new PreferenceStorage(PLUGIN_ID,
+			DefaultScope.INSTANCE);
+
+	private static final PreferenceStorage CURRENT_SCOPE_PREFS = new PreferenceStorage(PLUGIN_ID,
+			InstanceScope.INSTANCE, DefaultScope.INSTANCE);
+
+	private static final String DEFAULT_CACHE_DIR = System.getProperty("java.io.tmpdir") + File.separator
+			+ "bert-cache";
+
+	/**
+	 * Accessed by preference page.
+	 */
+	static final PythonConfigStorage CURRENT = new PreferenceWrappingConfigStorage(CURRENT_SCOPE_PREFS);
+
+	/**
+	 * Accessed by preference page and preferences initializer.
+	 */
+	static final PythonConfigStorage DEFAULT = new PreferenceWrappingConfigStorage(DEFAULT_SCOPE_PREFS);
+
+	static final String BUNDLED_ENV_ID = "se_redfield_bert";
+
+	private static PythonEnvironmentType getEnvironmentTypePreference() {
+		var config = createAndLoadCurrent(PythonEnvironmentTypeConfig::new);
+		return PythonEnvironmentType.fromId(config.getEnvironmentType().getStringValue());
+	}
+
+	private static <T extends PythonConfig> T createAndLoadCurrent(final Supplier<T> supplier) {
+		var config = supplier.get();
+		config.loadConfigFrom(CURRENT);
+		return config;
+	}
+
+	static BundledCondaEnvironmentConfig createBundledEnvConfig() {
+		return new BundledCondaEnvironmentConfig(BUNDLED_ENV_ID);
+	}
+
+	static PythonEnvironmentTypeConfig createEnvTypeConfig() {
+		return new PythonEnvironmentTypeConfig(PythonEnvironmentType.BUNDLED);
+	}
+
+	static CondaEnvironmentsConfig createCondaEnvConfig() {
+		return new CondaEnvironmentsConfig();
+	}
+
+	static ManualEnvironmentsConfig createManualEnvConfig() {
+		return new ManualEnvironmentsConfig();
+	}
+
+	static StringPythonConfig createCacheDirConfig() {
+		return new StringPythonConfig("cachedir", DEFAULT_CACHE_DIR);
+	}
+
+	private static PythonEnvironmentsConfig getCurrentEnvironmentConfig() {
+		var envType = getEnvironmentTypePreference();
+		switch (envType) {
+		case BUNDLED:
+			return createAndLoadCurrent(BertPreferences::createBundledEnvConfig);
+		case CONDA:
+			return createAndLoadCurrent(BertPreferences::createCondaEnvConfig);
+		case MANUAL:
+			return createAndLoadCurrent(BertPreferences::createManualEnvConfig);
+		default:
+			throw new IllegalStateException("Unknown environment type encountered: " + envType);
+		}
+	}
+
+	/**
+	 * @return the PythonCommand configured on the preference page
+	 */
+	public static PythonCommand getPythonCommandPreference() {
+		return getCurrentEnvironmentConfig()//
+				.getPython3Config()//
+				.getPythonCommand();
+	}
+
+	/**
+	 * @return the absolute path to the cache directory
+	 */
+	public static String getCacheDir() {
+		var cacheDir = createAndLoadCurrent(BertPreferences::createCacheDirConfig).getValue();
+		try {
+			Files.createDirectories(Path.of(cacheDir));
+		} catch (IOException e) {
+			// it's fine if it can't be created, then the user will just have to choose a different one
+			NodeLogger.getLogger(BertPreferences.class).error("Failed to create BERT cache directory.", e);
+		}
+		return cacheDir;
+	}
+
+	private BertPreferences() {
+	}
+}

--- a/se.redfield.bert/src/se/redfield/bert/prefs/BundledEnvironmentConfigsObserver.java
+++ b/se.redfield.bert/src/se/redfield/bert/prefs/BundledEnvironmentConfigsObserver.java
@@ -436,7 +436,7 @@ final class BundledEnvironmentConfigsObserver extends AbstractPythonConfigsObser
 					environmentConfig.getEnvironmentDirectory().setStringValue(createdEnvironment.getDirectoryPath());
 					testPythonEnvironment(true);
 				} catch (Exception ex) {
-					// Ignore, we still want to configure and test the second environment.
+					// Ignore
 				}
 			}
 

--- a/se.redfield.bert/src/se/redfield/bert/prefs/BundledEnvironmentConfigsObserver.java
+++ b/se.redfield.bert/src/se/redfield/bert/prefs/BundledEnvironmentConfigsObserver.java
@@ -1,0 +1,455 @@
+/*
+ * ------------------------------------------------------------------------
+ *
+ *  Copyright by KNIME AG, Zurich, Switzerland
+ *  Website: http://www.knime.com; Email: contact@knime.com
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License, Version 3, as
+ *  published by the Free Software Foundation.
+ *
+ *  This program is distributed in the hope that it will be useful, but
+ *  WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, see <http://www.gnu.org/licenses>.
+ *
+ *  Additional permission under GNU GPL version 3 section 7:
+ *
+ *  KNIME interoperates with ECLIPSE solely via ECLIPSE's plug-in APIs.
+ *  Hence, KNIME and ECLIPSE are both independent programs and are not
+ *  derived from each other. Should, however, the interpretation of the
+ *  GNU GPL Version 3 ("License") under any applicable laws result in
+ *  KNIME and ECLIPSE being a combined program, KNIME AG herewith grants
+ *  you the additional permission to use and propagate KNIME together with
+ *  ECLIPSE with only the license terms in place for ECLIPSE applying to
+ *  ECLIPSE and the GNU GPL Version 3 applying for KNIME, provided the
+ *  license terms of ECLIPSE themselves allow for the respective use and
+ *  propagation of ECLIPSE together with KNIME.
+ *
+ *  Additional permission relating to nodes for KNIME that extend the Node
+ *  Extension (and in particular that are based on subclasses of NodeModel,
+ *  NodeDialog, and NodeView) and that only interoperate with KNIME through
+ *  standard APIs ("Nodes"):
+ *  Nodes are deemed to be separate and independent programs and to not be
+ *  covered works.  Notwithstanding anything to the contrary in the
+ *  License, the License does not apply to Nodes, you are not required to
+ *  license Nodes under the License, and you are granted a license to
+ *  prepare and propagate Nodes, in each case even if such Nodes are
+ *  propagated with or for interoperation with KNIME.  The owner of a Node
+ *  may freely choose the license terms applicable to such Node, including
+ *  when such Node is propagated with or for interoperation with KNIME.
+ * ---------------------------------------------------------------------
+ *
+ * History
+ *   Jan 25, 2019 (marcel): created
+ */
+package se.redfield.bert.prefs;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+import org.knime.conda.Conda;
+import org.knime.conda.CondaEnvironmentIdentifier;
+import org.knime.conda.prefs.CondaPreferences;
+import org.knime.core.node.defaultnodesettings.SettingsModelString;
+import org.knime.python2.PythonCommand;
+import org.knime.python2.PythonKernelTester;
+import org.knime.python2.PythonModuleSpec;
+import org.knime.python2.PythonVersion;
+import org.knime.python2.PythonKernelTester.PythonKernelTestResult;
+import org.knime.python2.config.AbstractCondaEnvironmentCreationObserver;
+import org.knime.python2.config.AbstractCondaEnvironmentsPanel;
+import org.knime.python2.config.AbstractPythonConfigsObserver;
+import org.knime.python2.config.CondaEnvironmentConfig;
+import org.knime.python2.config.CondaEnvironmentsConfig;
+import org.knime.python2.config.ManualEnvironmentConfig;
+import org.knime.python2.config.ManualEnvironmentsConfig;
+import org.knime.python2.config.PythonConfigsObserver;
+import org.knime.python2.config.PythonEnvironmentConfig;
+import org.knime.python2.config.PythonEnvironmentType;
+import org.knime.python2.config.PythonEnvironmentTypeConfig;
+import org.knime.python2.config.PythonEnvironmentsConfig;
+import org.knime.python2.config.SerializerConfig;
+import org.knime.python2.config.AbstractCondaEnvironmentCreationObserver.CondaEnvironmentCreationStatus;
+import org.knime.python2.config.AbstractCondaEnvironmentCreationObserver.CondaEnvironmentCreationStatusListener;
+import org.knime.python3.scripting.nodes.prefs.BundledCondaEnvironmentConfig;
+
+/**
+ * Specialization of the {@link PythonConfigsObserver} for nodes that come with
+ * a bundled environment.
+ *
+ * @author Adrian Nembach, KNIME GmbH, Konstanz, Germany
+ */
+final class BundledEnvironmentConfigsObserver extends AbstractPythonConfigsObserver {
+
+	private final BundledCondaEnvironmentConfig m_bundledCondaEnvironmentConfig;
+
+	private final String m_featureName;
+
+	private final List<PythonModuleSpec> m_additionalRequiredModules;
+
+	private final PythonEnvironmentTypeConfig m_environmentTypeConfig;
+
+	private final CondaEnvironmentsConfig m_condaEnvironmentsConfig;
+
+	private final AbstractCondaEnvironmentCreationObserver m_condaEnvironmentCreator;
+
+	private final ManualEnvironmentsConfig m_manualEnvironmentsConfig;
+
+	private final PythonEnvironmentSelectionConfig m_config;
+
+	BundledEnvironmentConfigsObserver(//
+			PythonEnvironmentSelectionConfig config,
+			final AbstractCondaEnvironmentCreationObserver condaEnvironmentCreator, //
+			String featureName, //
+			Collection<PythonModuleSpec> additionalRequirements//
+	) {
+		m_config = config;
+		m_bundledCondaEnvironmentConfig = config.getBundledCondaEnvironmentConfig();
+		m_condaEnvironmentsConfig = config.getCondaEnvironmentsConfig();
+		m_manualEnvironmentsConfig = config.getManualEnvironmentsConfig();
+		m_environmentTypeConfig = config.getEnvironmentTypeConfig();
+		m_condaEnvironmentCreator = condaEnvironmentCreator;
+		m_featureName = featureName;
+		m_additionalRequiredModules = List.copyOf(additionalRequirements);
+
+		// Initialize view-model of default Python environment (since this was/is not
+		// persisted):
+
+		updateDefaultPythonEnvironment();
+
+		// Test all environments of the respective type on environment type change:
+		m_config.getEnvironmentTypeConfig().getEnvironmentType().addChangeListener(e -> {
+			updateDefaultPythonEnvironment();
+			testCurrentPreferences();
+		});
+
+		// Test Conda environments on change:
+		m_config.getCondaEnvironmentsConfig().getPython3Config().getEnvironmentDirectory()
+				.addChangeListener(e -> testPythonEnvironment(true));
+
+		// Disable Conda environment creation by default, updated when Conda
+		// installation is tested.
+		condaEnvironmentCreator.getIsEnvironmentCreationEnabled().setBooleanValue(false);
+
+		// Handle finished Conda environment creation processes:
+		observeEnvironmentCreation(condaEnvironmentCreator);
+
+		// Test manual environments on change:
+		m_config.getManualEnvironmentsConfig().getPython3Config().getExecutablePath()
+				.addChangeListener(e -> testPythonEnvironment(false));
+
+		// Test required external modules of serializer on change:
+	}
+
+	/**
+	 * @return The currently selected PythonEnvironmentType
+	 */
+	protected PythonEnvironmentType getEnvironmentType() {
+		return PythonEnvironmentType.fromId(m_environmentTypeConfig.getEnvironmentType().getStringValue());
+	}
+
+	/**
+	 * @return The environments of the current type. Can be overloaded to support
+	 *         bundled conda environments.
+	 */
+	protected PythonEnvironmentsConfig getEnvironmentsOfCurrentType() {
+		final var environmentType = getEnvironmentType();
+		if (PythonEnvironmentType.BUNDLED == environmentType) {
+			return m_bundledCondaEnvironmentConfig;
+		} else if (PythonEnvironmentType.CONDA == environmentType) {
+			return m_condaEnvironmentsConfig;
+		} else if (PythonEnvironmentType.MANUAL == environmentType) {
+			return m_manualEnvironmentsConfig;
+		} else {
+			throw unknownEnvType(environmentType);
+		}
+	}
+
+	private static IllegalStateException unknownEnvType(final PythonEnvironmentType environmentType) {
+		return new IllegalStateException("Selected environment type '" + environmentType.getName() + "' is neither "
+				+ "bundled nor conda nor manual. This is an implementation error.");
+	}
+
+	private void updateDefaultPythonEnvironment() {
+		if (PythonEnvironmentType.BUNDLED.equals(getEnvironmentType())) {
+			// We do not configure a default environment if bundling is selected,
+			// that will happen once the user selects "Conda" or "Manual" for the first
+			// time.
+			return;
+		}
+
+		final List<PythonEnvironmentConfig> notDefaultEnvironments = new ArrayList<>(4);
+		Collections.addAll(notDefaultEnvironments, m_condaEnvironmentsConfig.getPython2Config(),
+				m_condaEnvironmentsConfig.getPython3Config(), m_manualEnvironmentsConfig.getPython2Config(),
+				m_manualEnvironmentsConfig.getPython3Config());
+
+		final PythonEnvironmentsConfig environmentsOfCurrentType = getEnvironmentsOfCurrentType();
+		final PythonEnvironmentConfig defaultEnvironment = environmentsOfCurrentType.getPython3Config();
+		notDefaultEnvironments.remove(defaultEnvironment);
+
+		for (final var notDefaultEnvironment : notDefaultEnvironments) {
+			notDefaultEnvironment.getIsDefaultPythonEnvironment().setBooleanValue(false);
+		}
+		defaultEnvironment.getIsDefaultPythonEnvironment().setBooleanValue(true);
+	}
+
+	/**
+	 * Initiates installation tests for all environments of the currently selected
+	 * {@link PythonEnvironmentType} as well as for the currently selected
+	 * serializer. Depending on the selected environment type, the status of each of
+	 * these tests is published to all installation status models in either the
+	 * observed {@link CondaEnvironmentConfig} or the observed
+	 * {@link ManualEnvironmentConfig}. Also to the installation error model of the
+	 * observed {@link SerializerConfig}.
+	 */
+	public void testCurrentPreferences() {
+		final PythonEnvironmentType environmentType = getEnvironmentType();
+		switch (environmentType) {
+		case BUNDLED:
+			if (!m_bundledCondaEnvironmentConfig.isAvailable()) {
+				m_bundledCondaEnvironmentConfig.getPythonInstallationError()
+						.setStringValue(String.format(
+								"Bundled Conda environment is not available please reinstall the '%s' feature.",
+								m_featureName));
+			}
+			break;
+		case CONDA:
+			refreshAndTestCondaConfig();
+			break;
+		case MANUAL:
+			testPythonEnvironment(false);
+			break;
+		default:
+			throw unknownEnvType(environmentType);
+		}
+	}
+
+	private void refreshAndTestCondaConfig() {
+		new Thread(() -> {
+			final Conda conda;
+			try {
+				conda = testCondaInstallation();
+			} catch (final Exception ex) {
+				return;
+			}
+			final List<CondaEnvironmentIdentifier> availableEnvironments;
+			try {
+				availableEnvironments = getAvailableCondaEnvironments(conda, true);
+			} catch (final Exception ex) {
+				return;
+			}
+
+			try {
+				setAvailableCondaEnvironments(availableEnvironments);
+				testPythonEnvironment(true);
+			} catch (Exception ex) {
+				// Ignore
+			}
+		}).start();
+	}
+
+	private Conda testCondaInstallation() throws Exception {
+		final SettingsModelString condaInfoMessage = m_condaEnvironmentsConfig.getCondaInstallationInfo();
+		final SettingsModelString condaErrorMessage = m_condaEnvironmentsConfig.getCondaInstallationError();
+		try {
+			condaInfoMessage.setStringValue("Testing Conda installation...");
+			condaErrorMessage.setStringValue("");
+			onCondaInstallationTestStarting();
+			final String condaDir = CondaPreferences.getCondaInstallationDirectory();
+			final Conda conda = new Conda(condaDir);
+			conda.testInstallation();
+			String condaVersionString = conda.getVersionString();
+			try {
+				condaVersionString = "Conda version: "
+						+ Conda.condaVersionStringToVersion(condaVersionString).toString();
+			} catch (final IllegalArgumentException ex) {
+				// Ignore and use raw version string.
+			}
+			condaInfoMessage.setStringValue("Using Conda at '" + condaDir + "'. " + condaVersionString);
+			condaErrorMessage.setStringValue("");
+			m_condaEnvironmentCreator.getIsEnvironmentCreationEnabled().setBooleanValue(true);
+			onCondaInstallationTestFinished("");
+			return conda;
+		} catch (final Exception ex) {
+			condaInfoMessage.setStringValue("");
+			condaErrorMessage.setStringValue(ex.getMessage());
+			clearAvailableCondaEnvironments();
+			setCondaEnvironmentStatusMessages("", "");
+			m_condaEnvironmentCreator.getIsEnvironmentCreationEnabled().setBooleanValue(false);
+			onCondaInstallationTestFinished(ex.getMessage());
+			throw ex;
+		}
+	}
+
+	private List<CondaEnvironmentIdentifier> getAvailableCondaEnvironments(final Conda conda,
+			final boolean updatePython3StatusMessage) throws Exception {
+		try {
+			final String determiningEnvironmentsMessage = "Collecting available environments...";
+			if (updatePython3StatusMessage) {
+				setCondaEnvironmentStatusMessages(determiningEnvironmentsMessage, "");
+			}
+			return conda.getEnvironments();
+		} catch (final Exception ex) {
+			m_condaEnvironmentsConfig.getCondaInstallationError().setStringValue(ex.getMessage());
+			final String environmentsNotDetectedMessage = "Available environments could not be detected.";
+			clearAvailableCondaEnvironments();
+			setCondaEnvironmentStatusMessages("", environmentsNotDetectedMessage);
+			throw ex;
+		}
+	}
+
+	private void clearAvailableCondaEnvironments() {
+		setAvailableCondaEnvironments(Collections.emptyList());
+	}
+
+	private void setCondaEnvironmentStatusMessages(final String infoMessage, final String errorMessage) {
+		final CondaEnvironmentConfig condaEnvironmentConfig = m_condaEnvironmentsConfig.getPython3Config();
+		condaEnvironmentConfig.getPythonInstallationInfo().setStringValue(infoMessage);
+		condaEnvironmentConfig.getPythonInstallationError().setStringValue(errorMessage);
+	}
+
+	private void setAvailableCondaEnvironments(List<CondaEnvironmentIdentifier> availableEnvironments) {
+		final CondaEnvironmentConfig condaConfig = m_condaEnvironmentsConfig.getPython3Config();
+		if (availableEnvironments.isEmpty()) {
+			availableEnvironments = Arrays.asList(CondaEnvironmentIdentifier.PLACEHOLDER_CONDA_ENV);
+		}
+		condaConfig.getAvailableEnvironments()
+				.setValue(availableEnvironments.toArray(new CondaEnvironmentIdentifier[0]));
+		final String currentlySelectedEnvironment = condaConfig.getEnvironmentDirectory().getStringValue();
+		if (availableEnvironments.stream()
+				.noneMatch(env -> Objects.equals(env.getDirectoryPath(), currentlySelectedEnvironment))) {
+			condaConfig.getEnvironmentDirectory().setStringValue(availableEnvironments.get(0).getDirectoryPath());
+		}
+	}
+
+	private void testPythonEnvironment(final boolean isConda) {
+		final PythonEnvironmentsConfig environmentsConfig;
+		final PythonEnvironmentType environmentType;
+		boolean isCondaPlaceholder = false;
+		if (isConda) {
+			if (isPlaceholderEnvironmentSelected()) {
+				// We don't want to test the placeholder but just clear the installation status
+				// messages and return.
+				isCondaPlaceholder = true;
+			}
+			environmentsConfig = m_condaEnvironmentsConfig;
+			environmentType = PythonEnvironmentType.CONDA;
+		} else {
+			environmentsConfig = m_manualEnvironmentsConfig;
+			environmentType = PythonEnvironmentType.MANUAL;
+		}
+		final PythonEnvironmentConfig environmentConfig;
+		final PythonVersion pythonVersion;
+		environmentConfig = environmentsConfig.getPython3Config();
+		pythonVersion = PythonVersion.PYTHON3;
+		final SettingsModelString infoMessage = environmentConfig.getPythonInstallationInfo();
+		final SettingsModelString errorMessage = environmentConfig.getPythonInstallationError();
+		final String environmentCreationInfo;
+		if (isConda) {
+			environmentCreationInfo = String.format(
+					"\nNote: You can create a new %s Conda environment that contains all packages\nrequired by "
+							+ "the %s by clicking the '%s' button\nabove.",
+					pythonVersion.getName(), m_featureName,
+					AbstractCondaEnvironmentsPanel.CREATE_NEW_ENVIRONMENT_BUTTON_TEXT);
+		} else {
+			environmentCreationInfo = String.format(
+					"\nNote: An easy way to create a new Conda environment that contains all packages\n"
+							+ "required by the %s can be found on the '%s' tab of this preference page.",
+					m_featureName, PythonEnvironmentType.CONDA.getName());
+		}
+		if (isCondaPlaceholder) {
+			infoMessage.setStringValue("");
+			errorMessage.setStringValue("No environment available. Please create a new one to be able to use "
+					+ pythonVersion.getName() + "." + environmentCreationInfo);
+			return;
+		}
+		final Collection<PythonModuleSpec> requiredSerializerModules = getAdditionalRequiredModules();
+		infoMessage.setStringValue("Testing " + pythonVersion.getName() + " environment...");
+		errorMessage.setStringValue("");
+		new Thread(() -> {
+			onEnvironmentInstallationTestStarting(environmentType, pythonVersion);
+			final PythonCommand pythonCommand = environmentConfig.getPythonCommand();
+			final PythonKernelTestResult testResult = PythonKernelTester.testPython3Installation(pythonCommand,
+					requiredSerializerModules, true);
+			infoMessage.setStringValue(testResult.getVersion());
+			String errorLog = testResult.getErrorLog();
+			if (errorLog != null && !errorLog.isEmpty()) {
+				errorLog += environmentCreationInfo;
+			}
+			errorMessage.setStringValue(errorLog);
+			onEnvironmentInstallationTestFinished(environmentType, pythonVersion, testResult);
+		}).start();
+	}
+
+	/**
+	 * Provides any additional modules that are required for the environment to be
+	 * valid. By default these are the requirements of the selected serialization
+	 * library.
+	 *
+	 * @return any additional modules that have to be present
+	 */
+	protected Collection<PythonModuleSpec> getAdditionalRequiredModules() {
+		return m_additionalRequiredModules;
+	}
+
+	private boolean isPlaceholderEnvironmentSelected() {
+		final SettingsModelString condaEnvironmentDirectory = m_condaEnvironmentsConfig.getPython3Config()
+				.getEnvironmentDirectory();
+		return CondaEnvironmentIdentifier.PLACEHOLDER_CONDA_ENV.getDirectoryPath()
+				.equals(condaEnvironmentDirectory.getStringValue());
+	}
+
+	private void observeEnvironmentCreation(final AbstractCondaEnvironmentCreationObserver creationStatus) {
+		creationStatus.addEnvironmentCreationStatusListener(new CondaEnvironmentCreationStatusListener() {
+
+			@Override
+			public void condaEnvironmentCreationStarting(final CondaEnvironmentCreationStatus status) {
+				// no-op
+			}
+
+			@Override
+			public void condaEnvironmentCreationFinished(final CondaEnvironmentCreationStatus status,
+					final CondaEnvironmentIdentifier createdEnvironment) {
+				final Conda conda;
+				try {
+					conda = testCondaInstallation();
+				} catch (final Exception ex) {
+					return;
+				}
+				final List<CondaEnvironmentIdentifier> availableEnvironments;
+				try {
+					availableEnvironments = getAvailableCondaEnvironments(conda, true);
+				} catch (final Exception ex) {
+					return;
+				}
+				try {
+					setAvailableCondaEnvironments(availableEnvironments);
+					final CondaEnvironmentConfig environmentConfig = m_condaEnvironmentsConfig.getPython3Config();
+					environmentConfig.getEnvironmentDirectory().setStringValue(createdEnvironment.getDirectoryPath());
+					testPythonEnvironment(true);
+				} catch (Exception ex) {
+					// Ignore, we still want to configure and test the second environment.
+				}
+			}
+
+			@Override
+			public void condaEnvironmentCreationCanceled(final CondaEnvironmentCreationStatus status) {
+				// no-op
+			}
+
+			@Override
+			public void condaEnvironmentCreationFailed(final CondaEnvironmentCreationStatus status,
+					final String errorMessage) {
+				// no-op
+			}
+		}, false);
+	}
+}

--- a/se.redfield.bert/src/se/redfield/bert/prefs/CustomCondaEnvironmentsPreferencePanel.java
+++ b/se.redfield.bert/src/se/redfield/bert/prefs/CustomCondaEnvironmentsPreferencePanel.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2021 Redfield AB.
+*/
+package se.redfield.bert.prefs;
+
+import java.util.function.Consumer;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Shell;
+import org.knime.python2.PythonVersion;
+import org.knime.python2.config.AbstractCondaEnvironmentCreationObserver;
+import org.knime.python2.config.CondaEnvironmentsConfig;
+import org.knime.python2.prefs.CondaDirectoryPathStatusPanel;
+import org.knime.python2.prefs.CondaEnvironmentSelectionBox;
+
+final class CustomCondaEnvironmentsPreferencePanel {
+
+	private final Composite m_panel;
+
+	private final CondaEnvironmentsConfig m_config;
+
+	CustomCondaEnvironmentsPreferencePanel(final Composite parent, CondaEnvironmentsConfig config,
+			String envConsumerName, AbstractCondaEnvironmentCreationObserver environmentCreator,
+			Consumer<Shell> openCreationDialog) {
+		m_panel = new Composite(parent, SWT.NONE);
+		m_panel.setLayout(new GridLayout());
+		m_config = config;
+		addCondaDirPathStatusWidget();
+		addPythonEnvWidget(envConsumerName, environmentCreator, openCreationDialog);
+	}
+
+	private void addCondaDirPathStatusWidget() {
+		final CondaDirectoryPathStatusPanel statusPanel = new CondaDirectoryPathStatusPanel(
+				m_config.getCondaInstallationInfo(), m_config.getCondaInstallationError(), m_panel);
+		final GridData gridData = new GridData();
+		gridData.grabExcessHorizontalSpace = true;
+		gridData.horizontalAlignment = SWT.FILL;
+		statusPanel.setLayoutData(gridData);
+	}
+
+	private void addPythonEnvWidget(String envConsumerName, AbstractCondaEnvironmentCreationObserver envCreator,
+			Consumer<Shell> openCreationDialog) {
+		var envConfig = m_config.getPython3Config();
+		var envSelectionBox = new CondaEnvironmentSelectionBox(//
+				PythonVersion.PYTHON3, //
+				envConfig.getEnvironmentDirectory(), //
+				envConfig.getAvailableEnvironments(), //
+				envConsumerName, //
+				"Name of the " + envConsumerName + " Conda environment", //
+				envConfig.getPythonInstallationInfo(), //
+				envConfig.getPythonInstallationWarning(), //
+				envConfig.getPythonInstallationError(), //
+				envCreator, //
+				m_panel, //
+				openCreationDialog//
+		);
+		final GridData gridData = new GridData();
+        gridData.horizontalAlignment = SWT.FILL;
+//        gridData.horizontalIndent = 20;
+        gridData.grabExcessHorizontalSpace = true;
+        envSelectionBox.setLayoutData(gridData);
+	}
+
+	Control getPanel() {
+		return m_panel;
+	}
+
+}

--- a/se.redfield.bert/src/se/redfield/bert/prefs/CustomCondaEnvironmentsPreferencePanel.java
+++ b/se.redfield.bert/src/se/redfield/bert/prefs/CustomCondaEnvironmentsPreferencePanel.java
@@ -60,7 +60,6 @@ final class CustomCondaEnvironmentsPreferencePanel {
 		);
 		final GridData gridData = new GridData();
         gridData.horizontalAlignment = SWT.FILL;
-//        gridData.horizontalIndent = 20;
         gridData.grabExcessHorizontalSpace = true;
         envSelectionBox.setLayoutData(gridData);
 	}

--- a/se.redfield.bert/src/se/redfield/bert/prefs/DirectoryChooser.java
+++ b/se.redfield.bert/src/se/redfield/bert/prefs/DirectoryChooser.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2021 Redfield AB.
+*/
+package se.redfield.bert.prefs;
+
+import org.eclipse.jface.preference.DirectoryFieldEditor;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Composite;
+import org.knime.core.node.defaultnodesettings.SettingsModelString;
+
+final class DirectoryChooser {
+
+	private final DirectoryFieldEditor m_cacheDirChooser;
+	
+	DirectoryChooser(final String name, String label, Composite parent, SettingsModelString model) {
+		m_cacheDirChooser = new DirectoryFieldEditor(name, label, parent);
+		m_cacheDirChooser.setStringValue(model.getStringValue());
+		model.addChangeListener(e -> m_cacheDirChooser.setStringValue(model.getStringValue()));
+		m_cacheDirChooser.getTextControl(parent).addListener(SWT.Traverse, event -> {
+			model.setStringValue(m_cacheDirChooser.getStringValue());
+			if (event.detail == SWT.TRAVERSE_RETURN) {
+				event.doit = false;
+			}
+		});
+		m_cacheDirChooser
+				.setPropertyChangeListener(event -> model.setStringValue(m_cacheDirChooser.getStringValue()));
+	}
+}

--- a/se.redfield.bert/src/se/redfield/bert/prefs/MultiOptionCondaEnvironmentCreationDialog.java
+++ b/se.redfield.bert/src/se/redfield/bert/prefs/MultiOptionCondaEnvironmentCreationDialog.java
@@ -1,0 +1,486 @@
+/*
+ * Copyright (c) 2021 Redfield AB.
+*/
+package se.redfield.bert.prefs;
+
+import static org.knime.python2.prefs.PythonPreferenceUtils.performActionOnWidgetInUiThread;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import javax.swing.event.ChangeEvent;
+
+import org.eclipse.jface.resource.JFaceResources;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.StackLayout;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.events.SelectionListener;
+import org.eclipse.swt.events.ShellEvent;
+import org.eclipse.swt.events.ShellListener;
+import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.graphics.Point;
+import org.eclipse.swt.layout.FillLayout;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.layout.RowLayout;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Dialog;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.ProgressBar;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swt.widgets.Text;
+import org.knime.conda.CondaEnvironmentIdentifier;
+import org.knime.python2.config.CondaEnvironmentCreationDialog;
+
+import se.redfield.bert.prefs.MultiOptionEnvironmentCreator.CondaEnvironmentCreationOption;
+
+import org.knime.python2.config.AbstractCondaEnvironmentCreationObserver.CondaEnvironmentCreationStatus;
+import org.knime.python2.config.AbstractCondaEnvironmentCreationObserver.CondaEnvironmentCreationStatusListener;
+
+final class MultiOptionCondaEnvironmentCreationDialog extends Dialog implements CondaEnvironmentCreationDialog {
+	
+	private static final String ENVIRONMENT_NAME_PLACEHOLDER = "Collecting existing environment names...";
+
+	private static final int DESCRIPTION_LABEL_WIDTH_HINTS = 300;
+
+	private final MultiOptionEnvironmentCreator m_environmentCreator;
+
+	// UI components: Initialized by #createContents().
+
+	private final Shell m_shell;
+
+	private Text m_environmentNameTextBox;
+
+	private Label m_statusLabel;
+
+	private StackLayout m_progressBarStackLayout;
+
+	private ProgressBar m_indeterminateProgressBar;
+
+	private ProgressBar m_determinateProgressBar;
+
+	private Label m_errorTextBoxLabel;
+
+	private Composite m_errorTextBoxContainer;
+
+	private Text m_errorTextBox;
+
+	private Button m_cancelButton;
+	
+	private final Map<Button, CondaEnvironmentCreationOption> m_buttonMap = new LinkedHashMap<>();
+
+	/**
+	 * Initialized when the {@link #switchToStartingOrRetryingState() create button
+	 * is clicked}.
+	 */
+	private volatile CondaEnvironmentCreationStatus m_status;
+
+	/**
+	 * Initialized by {@link #registerExternalHooks()}.
+	 */
+	private CondaEnvironmentCreationStatusListener m_statusChangeListener;
+
+	private volatile boolean m_environmentCreationTerminated = false;
+	
+	public MultiOptionCondaEnvironmentCreationDialog(final MultiOptionEnvironmentCreator environmentCreator,
+        final Shell parent, String name, String description) {
+        super(parent, SWT.NONE);
+        m_environmentCreator = environmentCreator;
+        m_shell = new Shell(parent, SWT.DIALOG_TRIM | SWT.SHEET | SWT.RESIZE);
+        m_shell.setText(String.format("New %s Conda environment", name));
+        createContents(description);
+        m_shell.pack();
+    }
+
+	private void createContents(String description) {
+		m_shell.setLayout(new GridLayout());
+		final Label descriptionText = new Label(m_shell, SWT.WRAP);
+		descriptionText.setText(description);
+		descriptionText.setFont(JFaceResources.getFontRegistry().getItalic(""));
+		GridData gridData = new GridData(SWT.FILL, SWT.CENTER, true, false);
+		gridData.widthHint = DESCRIPTION_LABEL_WIDTH_HINTS;
+		descriptionText.setLayoutData(gridData);
+
+		final Label separator = new Label(m_shell, SWT.SEPARATOR | SWT.HORIZONTAL);
+		separator.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+
+		final Composite environmentNameContainer = new Composite(m_shell, SWT.NONE);
+		environmentNameContainer.setLayoutData(new GridData(GridData.FILL, GridData.CENTER, true, false));
+		environmentNameContainer.setLayout(new GridLayout(2, false));
+
+		// Environment name:
+
+		final Label environmentNameTextBoxLabel = new Label(environmentNameContainer, SWT.NONE);
+		environmentNameTextBoxLabel.setText("New environment's name");
+		environmentNameTextBoxLabel.setLayoutData(new GridData());
+
+		m_environmentNameTextBox = new Text(environmentNameContainer, SWT.BORDER);
+		m_environmentNameTextBox.setEnabled(false);
+		m_environmentNameTextBox.setText(ENVIRONMENT_NAME_PLACEHOLDER);
+		m_environmentNameTextBox.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
+
+		// Progress monitoring widgets:
+
+		final Composite installationMonitorContainer = new Composite(m_shell, SWT.NONE);
+		installationMonitorContainer.setLayoutData(new GridData(GridData.FILL, GridData.FILL, true, true));
+		installationMonitorContainer.setLayout(new GridLayout());
+
+		m_statusLabel = new Label(installationMonitorContainer, SWT.WRAP);
+		m_statusLabel.setText("Please click one of the create buttons to start. "
+				+ "You can specify a custom environment name using the text field above before starting.");
+		gridData = new GridData(SWT.FILL, SWT.CENTER, true, false);
+		gridData.widthHint = DESCRIPTION_LABEL_WIDTH_HINTS;
+		gridData.verticalIndent = 10;
+		m_statusLabel.setLayoutData(gridData);
+
+		final Composite progressBarContainer = new Composite(installationMonitorContainer, SWT.NONE);
+		progressBarContainer.setLayoutData(new GridData(GridData.FILL, GridData.CENTER, true, false));
+		m_progressBarStackLayout = new StackLayout();
+		progressBarContainer.setLayout(m_progressBarStackLayout);
+		m_determinateProgressBar = new ProgressBar(progressBarContainer, SWT.SMOOTH);
+		m_indeterminateProgressBar = new ProgressBar(progressBarContainer, SWT.SMOOTH | SWT.INDETERMINATE);
+		m_progressBarStackLayout.topControl = m_determinateProgressBar;
+
+		m_errorTextBoxLabel = new Label(installationMonitorContainer, SWT.NONE);
+		m_errorTextBoxLabel.setText("Conda error log");
+		gridData = new GridData();
+		gridData.verticalIndent = 10;
+		m_errorTextBoxLabel.setLayoutData(gridData);
+
+		m_errorTextBoxContainer = new Composite(installationMonitorContainer, SWT.NONE);
+		gridData = new GridData(GridData.FILL, GridData.FILL, true, true);
+		gridData.heightHint = 80;
+		m_errorTextBoxContainer.setLayoutData(gridData);
+		m_errorTextBoxContainer.setLayout(new FillLayout());
+		m_errorTextBox = new Text(m_errorTextBoxContainer,
+				SWT.READ_ONLY | SWT.MULTI | SWT.WRAP | SWT.V_SCROLL | SWT.BORDER);
+		final Color red = new Color(m_errorTextBoxContainer.getDisplay(), 255, 0, 0);
+		m_errorTextBox.setForeground(red);
+		m_errorTextBox.addDisposeListener(e -> red.dispose());
+
+		m_determinateProgressBar.setEnabled(false);
+		m_errorTextBox.setEnabled(false);
+
+		// Hide error log initially.
+		m_errorTextBoxLabel.setVisible(false);
+		((GridData) m_errorTextBoxLabel.getLayoutData()).exclude = true;
+		m_errorTextBoxContainer.setVisible(false);
+		((GridData) m_errorTextBoxContainer.getLayoutData()).exclude = true;
+
+		// --
+
+		final Composite buttonContainer = new Composite(m_shell, SWT.NONE);
+		gridData = new GridData();
+		gridData.horizontalAlignment = SWT.RIGHT;
+		gridData.verticalIndent = 15;
+		buttonContainer.setLayoutData(gridData);
+		buttonContainer.setLayout(new RowLayout());
+		
+		for (var option : m_environmentCreator.getCreationOptions()) {
+			var button = new Button(buttonContainer, SWT.NONE);
+			button.setText(String.format("Create new %s environment", option.getName()));
+			button.setEnabled(false);
+			button.addSelectionListener(new SelectionListener() {
+
+				@Override
+				public void widgetSelected(SelectionEvent e) {
+					switchToStartingOrRetryingState(option);
+				}
+
+				@Override
+				public void widgetDefaultSelected(SelectionEvent e) {
+					widgetSelected(e);
+				}
+				
+			});
+			m_buttonMap.put(button, option);
+		}
+		
+		m_cancelButton = new Button(buttonContainer, SWT.NONE);
+		m_cancelButton.setText("Cancel");
+
+		// Initialize environment name: we're calling Conda here, so we should do this
+		// asynchronously.
+		new Thread(() -> {
+			final String defaultEnvironmentName = m_environmentCreator.getDefaultEnvironmentName();
+			switchToDefaultEnvironmentNameAvailableState(defaultEnvironmentName);
+		}).start();
+
+		// Internal hooks:
+
+
+		m_cancelButton.addSelectionListener(new SelectionListener() {
+
+			@Override
+			public void widgetSelected(final SelectionEvent e) {
+				if (m_status != null && !m_environmentCreationTerminated) {
+					m_environmentCreator.cancelEnvironmentCreation(m_status);
+					// Shell will be closed by the environment status listener's cancellation
+					// handler.
+				} else {
+					m_shell.close();
+				}
+			}
+
+			@Override
+			public void widgetDefaultSelected(final SelectionEvent e) {
+				widgetSelected(e);
+			}
+		});
+		m_shell.addShellListener(new ShellListener() {
+
+			@Override
+			public void shellIconified(final ShellEvent e) {
+				// no-op
+			}
+
+			@Override
+			public void shellDeiconified(final ShellEvent e) {
+				// no-op
+			}
+
+			@Override
+			public void shellDeactivated(final ShellEvent e) {
+				// no-op
+			}
+
+			@Override
+			public void shellClosed(final ShellEvent e) {
+				if (m_status != null && !m_environmentCreationTerminated) {
+					m_environmentCreator.cancelEnvironmentCreation(m_status);
+					// Shell will be closed by the environment status listener's cancellation/finish
+					// handlers.
+					e.doit = false;
+				}
+			}
+
+			@Override
+			public void shellActivated(final ShellEvent e) {
+				// no-op
+			}
+		});
+	}
+
+	public void open() {
+		try {
+			m_shell.open();
+			final Display display = getParent().getDisplay();
+			while (!m_shell.isDisposed()) {
+				if (!display.readAndDispatch()) {
+					display.sleep();
+				}
+			}
+		} finally {
+			unregisterExternalHooks();
+		}
+	}
+
+	/**
+	 * May be followed by starting state.
+	 */
+	private void switchToDefaultEnvironmentNameAvailableState(final String defaultEnvironmentName) {
+		performActionOnWidgetInUiThread(m_environmentNameTextBox, () -> {
+			m_environmentNameTextBox.setText(defaultEnvironmentName);
+			m_environmentNameTextBox.setEnabled(true);
+			m_environmentNameTextBox.setFocus();
+			m_environmentNameTextBox.getParent().layout();
+			for (var entry : m_buttonMap.entrySet()) {
+				entry.getKey().setEnabled(entry.getValue().isEnabled());
+			}
+			return null;
+		}, false);
+	}
+
+	/**
+	 * May be followed by finished, canceled, or failed state.
+	 */
+	private void switchToStartingOrRetryingState(CondaEnvironmentCreationOption creationOption) {
+		// If retrying.
+		m_environmentCreationTerminated = false;
+		m_statusLabel.setForeground(null);
+		m_errorTextBox.setText("");
+		unregisterExternalHooks();
+
+		m_environmentNameTextBox.setEnabled(false);
+		m_determinateProgressBar.setEnabled(true);
+		m_progressBarStackLayout.topControl = m_indeterminateProgressBar;
+		m_errorTextBox.setEnabled(true);
+		m_buttonMap.keySet().forEach(b -> b.setEnabled(false));
+		String environmentName = m_environmentNameTextBox.getText();
+		if (environmentName.isEmpty() || environmentName.equals(ENVIRONMENT_NAME_PLACEHOLDER)) {
+			// While the creator can handle empty environments names, we should also sync
+			// the dialog to let the
+			// user know which name we chose to overrule their empty text field input.
+			environmentName = m_environmentCreator.getDefaultEnvironmentName();
+			m_environmentNameTextBox.setText(environmentName);
+		}
+		m_shell.layout(true, true);
+		m_status = new CondaEnvironmentCreationStatus();
+		registerExternalHooks();
+		m_environmentCreator.startEnvironmentCreation(environmentName, m_status, creationOption);
+	}
+
+	/**
+	 * May be followed by starting state ("retry") or no state (terminal state).
+	 */
+	private void switchToFailedState() {
+		m_environmentCreationTerminated = true;
+		performActionOnWidgetInUiThread(m_shell, () -> {
+			if (!m_statusLabel.isDisposed()) {
+				final Color red = new Color(m_statusLabel.getDisplay(), 255, 0, 0);
+				m_statusLabel.setForeground(red);
+				m_statusLabel.addDisposeListener(e -> red.dispose());
+			}
+			if (!m_determinateProgressBar.isDisposed()) {
+				m_determinateProgressBar.setSelection(0);
+				m_determinateProgressBar.setEnabled(false);
+				m_progressBarStackLayout.topControl = m_determinateProgressBar;
+			}
+			if (!m_indeterminateProgressBar.isDisposed()) {
+				m_indeterminateProgressBar.setEnabled(false);
+			}
+			// Prepare for retry.
+			if (!m_environmentNameTextBox.isDisposed()) {
+				m_environmentNameTextBox.setEnabled(true);
+			}
+			
+			for (var entry : m_buttonMap.entrySet()) {
+				var button = entry.getKey();
+				if (!button.isDisposed()) {
+					var option = entry.getValue();
+					button.setText(String.format("Retry creating new %s environment", option.getName()));
+					button.setEnabled(option.isEnabled());
+				}
+			}
+			
+			m_shell.layout(true, true);
+			return null;
+		}, false);
+	}
+
+	/**
+	 * Terminal state.
+	 */
+	private void switchToFinishedState() {
+		m_environmentCreationTerminated = true;
+		performActionOnWidgetInUiThread(m_shell, () -> {
+			m_shell.close();
+			return null;
+		}, false);
+	}
+
+	/**
+	 * Terminal state.
+	 */
+	private void switchToCanceledState() {
+		switchToFinishedState();
+	}
+
+	private void registerExternalHooks() {
+		m_status.getStatusMessage().addChangeListener(this::updateStatusMessage);
+		m_status.getProgress().addChangeListener(this::updateProgress);
+		m_status.getErrorLog().addChangeListener(this::updateErrorLog);
+		m_statusChangeListener = new CondaEnvironmentCreationStatusListener() {
+
+			@Override
+			public void condaEnvironmentCreationStarting(final CondaEnvironmentCreationStatus status) {
+				// no-op
+			}
+
+			@Override
+			public void condaEnvironmentCreationFinished(final CondaEnvironmentCreationStatus status,
+					final CondaEnvironmentIdentifier createdEnvironment) {
+				if (status == m_status) {
+					switchToFinishedState();
+				}
+			}
+
+			@Override
+			public void condaEnvironmentCreationCanceled(final CondaEnvironmentCreationStatus status) {
+				if (status == m_status) {
+					switchToCanceledState();
+				}
+			}
+
+			@Override
+			public void condaEnvironmentCreationFailed(final CondaEnvironmentCreationStatus status,
+					final String errorMessage) {
+				if (status == m_status) {
+					switchToFailedState();
+				}
+			}
+		};
+		// Prepend to close dialog before installation tests on the preference page are
+		// triggered.
+		m_environmentCreator.addEnvironmentCreationStatusListener(m_statusChangeListener, true);
+	}
+
+	private void unregisterExternalHooks() {
+		if (m_status != null) {
+			m_status.getStatusMessage().removeChangeListener(this::updateStatusMessage);
+			m_status.getProgress().removeChangeListener(this::updateProgress);
+			m_status.getErrorLog().removeChangeListener(this::updateErrorLog);
+		}
+		m_environmentCreator.removeEnvironmentCreationStatusListener(m_statusChangeListener);
+	}
+
+	private void updateStatusMessage(@SuppressWarnings("unused") final ChangeEvent e) {
+		performActionOnWidgetInUiThread(m_statusLabel, () -> {
+			m_statusLabel.setText(m_status.getStatusMessage().getStringValue());
+			m_statusLabel.requestLayout();
+			return null;
+		}, true);
+	}
+
+	private void updateProgress(@SuppressWarnings("unused") final ChangeEvent e) {
+		final int progress = m_status.getProgress().getIntValue();
+		Control newVisibleProgressBar;
+		if (progress < 100) {
+			performActionOnWidgetInUiThread(m_determinateProgressBar, () -> {
+				m_determinateProgressBar.setSelection(progress);
+				m_determinateProgressBar.requestLayout();
+				return null;
+			}, true);
+			newVisibleProgressBar = m_determinateProgressBar;
+		} else {
+			newVisibleProgressBar = m_indeterminateProgressBar;
+		}
+		if (m_progressBarStackLayout.topControl != newVisibleProgressBar) {
+			m_progressBarStackLayout.topControl = newVisibleProgressBar;
+			performActionOnWidgetInUiThread(m_shell, () -> {
+				m_shell.layout(true, true);
+				return null;
+			}, true);
+		}
+	}
+
+	private void updateErrorLog(@SuppressWarnings("unused") final ChangeEvent e) {
+		performActionOnWidgetInUiThread(m_shell, () -> {
+			if (!m_errorTextBox.isDisposed()) {
+				m_errorTextBox.setText(m_status.getErrorLog().getStringValue());
+				m_errorTextBox.requestLayout();
+				if (!m_errorTextBoxContainer.isDisposed() && !m_errorTextBoxContainer.getVisible()) {
+					// Show error log if it is hidden (which is the initial state).
+					if (!m_errorTextBoxLabel.isDisposed()) {
+						m_errorTextBoxLabel.setVisible(true);
+						((GridData) m_errorTextBoxLabel.getLayoutData()).exclude = false;
+					}
+					m_errorTextBoxContainer.setVisible(true);
+					final GridData errorTextBoxContainerGridData = (GridData) m_errorTextBoxContainer.getLayoutData();
+					errorTextBoxContainerGridData.exclude = false;
+					m_shell.layout(true, true);
+					// Manually resize shell to show error log as if it wasn't hidden in the first
+					// place.
+					final Point oldSize = m_shell.getSize();
+					final Point newSize = m_shell.computeSize(oldSize.x,
+							oldSize.y + errorTextBoxContainerGridData.heightHint, true);
+					m_shell.setSize(newSize);
+				}
+			}
+			return null;
+		}, true);
+	}
+}

--- a/se.redfield.bert/src/se/redfield/bert/prefs/MultiOptionEnvironmentCreator.java
+++ b/se.redfield.bert/src/se/redfield/bert/prefs/MultiOptionEnvironmentCreator.java
@@ -41,8 +41,6 @@ final class MultiOptionEnvironmentCreator extends AbstractCondaEnvironmentCreati
 		return m_options;
 	}
 
-	// TODO disable GPU on Mac
-
 	static final class CondaEnvironmentCreationOption {
 
 		private final String m_name;

--- a/se.redfield.bert/src/se/redfield/bert/prefs/MultiOptionEnvironmentCreator.java
+++ b/se.redfield.bert/src/se/redfield/bert/prefs/MultiOptionEnvironmentCreator.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2021 Redfield AB.
+*/
+package se.redfield.bert.prefs;
+
+import java.util.List;
+
+import org.knime.python2.PythonVersion;
+import org.knime.python2.config.AbstractCondaEnvironmentCreationObserver;
+
+final class MultiOptionEnvironmentCreator extends AbstractCondaEnvironmentCreationObserver {
+
+	private final String m_description;
+
+	private final String m_defaultEnvironmentName;
+	
+	private final List<CondaEnvironmentCreationOption> m_options;
+
+	public MultiOptionEnvironmentCreator(String description, String defaultEnvironmentName,
+			CondaEnvironmentCreationOption... options) {
+		super(PythonVersion.PYTHON3);
+		m_description = description;
+		m_defaultEnvironmentName = defaultEnvironmentName;
+		m_options = List.of(options);
+	}
+
+	String getDescription() {
+		return m_description;
+	}
+
+	String getDefaultEnvironmentName() {
+		return m_defaultEnvironmentName;
+	}
+
+	void startEnvironmentCreation(String environmentName, CondaEnvironmentCreationStatus status,
+			CondaEnvironmentCreationOption creationOption) {
+		startEnvironmentCreation(environmentName, creationOption.m_pathToEnvYml, null, status);
+	}
+
+	List<CondaEnvironmentCreationOption> getCreationOptions() {
+		return m_options;
+	}
+
+	// TODO disable GPU on Mac
+
+	static final class CondaEnvironmentCreationOption {
+
+		private final String m_name;
+
+		private final boolean m_enable;
+		
+		private final String m_pathToEnvYml;
+
+		CondaEnvironmentCreationOption(String name, boolean enable, String pathToEnvYml) {
+			m_name = name;
+			m_enable = enable;
+			m_pathToEnvYml = pathToEnvYml;
+		}
+
+		String getName() {
+			return m_name;
+		}
+
+		boolean isEnabled() {
+			return m_enable;
+		}
+	}
+
+}

--- a/se.redfield.bert/src/se/redfield/bert/prefs/PreferenceUtils.java
+++ b/se.redfield.bert/src/se/redfield/bert/prefs/PreferenceUtils.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2021 Redfield AB.
+*/
+package se.redfield.bert.prefs;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Group;
+
+final class PreferenceUtils {
+
+	static Group createGroup(Composite container, final String groupName) {
+		final Group envConfigGroup = new Group(container, SWT.NONE);
+		envConfigGroup.setText(groupName);
+		final var layout = new GridLayout();
+		layout.marginWidth = 0;
+		layout.marginHeight = 0;
+		envConfigGroup.setLayout(layout);
+		envConfigGroup.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+		return envConfigGroup;
+	}
+
+	private PreferenceUtils() {
+
+	}
+}

--- a/se.redfield.bert/src/se/redfield/bert/prefs/PythonEnvironmentSelectionConfig.java
+++ b/se.redfield.bert/src/se/redfield/bert/prefs/PythonEnvironmentSelectionConfig.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2021 Redfield AB.
+*/
+package se.redfield.bert.prefs;
+
+import java.util.List;
+
+import org.knime.python2.config.CondaEnvironmentsConfig;
+import org.knime.python2.config.ManualEnvironmentsConfig;
+import org.knime.python2.config.PythonConfig;
+import org.knime.python2.config.PythonConfigStorage;
+import org.knime.python2.config.PythonEnvironmentTypeConfig;
+import org.knime.python3.scripting.nodes.prefs.BundledCondaEnvironmentConfig;
+
+final class PythonEnvironmentSelectionConfig implements PythonConfig {
+
+	private final PythonEnvironmentTypeConfig m_environmentTypeConfig;
+
+	private final CondaEnvironmentsConfig m_condaEnvironmentsConfig;
+
+	private final ManualEnvironmentsConfig m_manualEnvironmentsConfig;
+
+	private final BundledCondaEnvironmentConfig m_bundledCondaEnvironmentConfig;
+
+	private final List<PythonConfig> m_configs;
+
+	PythonEnvironmentSelectionConfig(final PythonEnvironmentTypeConfig envTypeConfig, CondaEnvironmentsConfig condaEnvConfig,
+			ManualEnvironmentsConfig manualEnvConfig, BundledCondaEnvironmentConfig bundledEnvConfig) {
+		m_environmentTypeConfig = envTypeConfig;
+		m_condaEnvironmentsConfig = condaEnvConfig;
+		m_manualEnvironmentsConfig = manualEnvConfig;
+		m_bundledCondaEnvironmentConfig = bundledEnvConfig;
+		m_configs = List.of(m_environmentTypeConfig, m_condaEnvironmentsConfig, m_manualEnvironmentsConfig,
+				m_bundledCondaEnvironmentConfig);
+	}
+	
+	List<PythonConfig> getConfigs() {
+		return m_configs;
+	}
+	
+	PythonEnvironmentTypeConfig getEnvironmentTypeConfig() {
+		return m_environmentTypeConfig;
+	}
+
+	CondaEnvironmentsConfig getCondaEnvironmentsConfig() {
+		return m_condaEnvironmentsConfig;
+	}
+
+	ManualEnvironmentsConfig getManualEnvironmentsConfig() {
+		return m_manualEnvironmentsConfig;
+	}
+
+	BundledCondaEnvironmentConfig getBundledCondaEnvironmentConfig() {
+		return m_bundledCondaEnvironmentConfig;
+	}
+
+	@Override
+	public void saveConfigTo(PythonConfigStorage storage) {
+		m_configs.forEach(c -> c.saveConfigTo(storage));
+	}
+	
+	@Override
+	public void saveDefaultsTo(PythonConfigStorage storage) {
+		m_configs.forEach(c -> c.saveConfigTo(storage));
+	}
+
+	@Override
+	public void loadConfigFrom(PythonConfigStorage storage) {
+		m_configs.forEach(c -> c.loadConfigFrom(storage));
+	}
+
+}

--- a/se.redfield.bert/src/se/redfield/bert/prefs/PythonEnvironmentSelectionPanel.java
+++ b/se.redfield.bert/src/se/redfield/bert/prefs/PythonEnvironmentSelectionPanel.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2021 Redfield AB.
+*/
+package se.redfield.bert.prefs;
+
+import org.eclipse.jface.util.IPropertyChangeListener;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.StackLayout;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Group;
+import org.eclipse.swt.widgets.Label;
+import org.knime.conda.prefs.CondaPreferences;
+import org.knime.python2.PythonVersion;
+import org.knime.python2.PythonKernelTester.PythonKernelTestResult;
+import org.knime.python2.config.PythonEnvironmentType;
+import org.knime.python2.config.AbstractPythonConfigsObserver.PythonConfigsInstallationTestStatusChangeListener;
+import org.knime.python2.prefs.ManualEnvironmentsPreferencePanel;
+import org.knime.python3.scripting.nodes.prefs.PythonBundledEnvironmentTypePreferencePanel;
+
+final class PythonEnvironmentSelectionPanel {
+
+	private final PythonEnvironmentSelectionConfig m_config;
+
+	private final StackLayout m_envConfigLayout;
+
+	private final MultiOptionEnvironmentCreator m_condaEnvironmentCreator;
+
+	private final CustomCondaEnvironmentsPreferencePanel m_condaEnvironmentPanel;
+
+	private final ManualEnvironmentsPreferencePanel m_manualEnvironmentPanel;
+
+	private final Composite m_bundledCondaEnvironmentPanel;
+
+	private final BundledEnvironmentConfigsObserver m_configObserver;
+	
+	private final IPropertyChangeListener m_condaDirPropertyChangeListener;
+	
+	PythonEnvironmentSelectionPanel(Composite parent, final PythonEnvironmentSelectionConfig config,
+			final MultiOptionEnvironmentCreator envCreator, BundledEnvironmentConfigsObserver configObserver) {
+		m_config = config;
+		m_condaEnvironmentCreator = envCreator;
+		m_configObserver = configObserver;
+		m_condaDirPropertyChangeListener = event -> {
+			if ("condaDirectoryPath".equals(event.getProperty()) && m_configObserver != null) {
+				m_configObserver.testCurrentPreferences();
+			}
+		};
+		final Group envConfigGroup = PreferenceUtils.createGroup(parent, "Python environment configuration");
+		new PythonBundledEnvironmentTypePreferencePanel(m_config.getEnvironmentTypeConfig(), envConfigGroup,
+				m_config.getBundledCondaEnvironmentConfig().isAvailable());
+		final Label separator = new Label(envConfigGroup, SWT.SEPARATOR | SWT.HORIZONTAL);
+		separator.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+
+		final Composite envConfigPanel = new Composite(envConfigGroup, SWT.NONE);
+		m_envConfigLayout = new StackLayout();
+		envConfigPanel.setLayout(m_envConfigLayout);
+		envConfigPanel.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+
+		m_condaEnvironmentPanel = new CustomCondaEnvironmentsPreferencePanel(envConfigPanel,
+				m_config.getCondaEnvironmentsConfig(), "BERT", m_condaEnvironmentCreator,
+				shell -> new MultiOptionCondaEnvironmentCreationDialog(m_condaEnvironmentCreator, shell, //
+						m_condaEnvironmentCreator.getDescription(), //
+						String.format(
+						"This will create a new preconfigured Python 3 Conda environment for the %s. "
+								+ "Creating the Conda environment may take several minutes and requires "
+								+ "an active internet connection.", m_condaEnvironmentCreator.getDescription())).open());
+
+		// Manual environment:
+		m_manualEnvironmentPanel = new ManualEnvironmentsPreferencePanel(m_config.getManualEnvironmentsConfig(),
+				envConfigPanel, false);
+
+		// Bundled Conda environment:
+		m_bundledCondaEnvironmentPanel = createBundledEnvPanel(envConfigPanel);
+	}
+	
+	private Composite createBundledEnvPanel(final Composite parent) {
+		final Composite panel = new Composite(parent, SWT.NONE);
+        panel.setLayout(new GridLayout());
+        var featureName = m_condaEnvironmentCreator.getDescription();
+		final String bundledEnvDescription = String.format("The %s extension provides its own Python environment.\n"
+				+ "If you select this option, then all its nodes that are configured to use\n"
+				+ " the settings from the preference page will make use of this bundled Python environment.\n\n\n"
+				+ "This bundled Python environment can not be extended.\n"
+				+ "If you need additional packages for your nodes (e.g. because you use third-party models),\n"
+				+ " use the \"Conda\" option above to change the environment for all %s \n"
+				+ "or use the Conda Environment Propagation node to set a Conda environment for selected nodes.\n",
+				featureName, featureName);
+
+        final Label environmentSelectionLabel = new Label(panel, SWT.NONE);
+        final var gridData = new GridData();
+        environmentSelectionLabel.setLayoutData(gridData);
+        environmentSelectionLabel.setText(bundledEnvDescription);
+        return panel;
+	}
+	
+	String reflectLoadedConfigurations() {
+		final var envType = m_config.getEnvironmentTypeConfig().getEnvironmentType();
+		var pythonEnvType = PythonEnvironmentType.fromId(envType.getStringValue());
+
+		String warning = null;
+		final var bundledEnvAvailable = m_config.getBundledCondaEnvironmentConfig().isAvailable();
+		if (PythonEnvironmentType.BUNDLED == pythonEnvType && !bundledEnvAvailable) {
+			warning = "You had previously selected the 'Bundled' option, but no bundled Python environment is available."
+					+ " Switched to 'Conda'.";
+			envType.setStringValue(PythonEnvironmentType.CONDA.getId());
+		} else if (PythonEnvironmentType.CONDA == pythonEnvType //
+				&& bundledEnvAvailable //
+				&& !BertPreferenceInitializer.isCondaConfigured()) {
+			warning = "You had previously selected the 'Conda' option, but Conda is not configured properly. "
+					+ "Switched to 'Bundled'.";
+			envType.setStringValue(PythonEnvironmentType.BUNDLED.getId());
+		}
+
+		displayPanelForEnvironmentType(envType.getStringValue());
+		return warning;
+	}
+	
+	private void displayPanelForEnvironmentType(final String environmentTypeId) {
+		final var environmentType = PythonEnvironmentType.fromId(environmentTypeId);
+		if (PythonEnvironmentType.CONDA == environmentType) {
+			m_envConfigLayout.topControl = m_condaEnvironmentPanel.getPanel();
+		} else if (PythonEnvironmentType.MANUAL == environmentType) {
+			m_envConfigLayout.topControl = m_manualEnvironmentPanel.getPanel();
+		} else if (PythonEnvironmentType.BUNDLED == environmentType) {
+			m_envConfigLayout.topControl = m_bundledCondaEnvironmentPanel;
+		} else {
+			throw new IllegalStateException(
+					"Selected Python environment type is neither Bundled, Conda, nor Manual. This is an implementation error.");
+		}
+	}
+	
+	void setupHooksAfterInitialization(Runnable resizeRunnable) {
+		m_config.getEnvironmentTypeConfig().getEnvironmentType().addChangeListener(
+				e -> displayPanelForEnvironmentType(m_config.getEnvironmentTypeConfig().getEnvironmentType().getStringValue()));
+
+		// Displaying installation test results may require resizing the scroll view.
+		m_configObserver.addConfigsTestStatusListener(new PythonConfigsInstallationTestStatusChangeListener() {
+
+			@Override
+			public void condaInstallationTestStarting() {
+				resizeRunnable.run();
+			}
+
+			@Override
+			public void condaInstallationTestFinished(final String errorMessage) {
+				resizeRunnable.run();
+			}
+
+			@Override
+			public void environmentInstallationTestStarting(final PythonEnvironmentType environmentType,
+					final PythonVersion pythonVersion) {
+				resizeRunnable.run();
+			}
+
+			@Override
+			public void environmentInstallationTestFinished(final PythonEnvironmentType environmentType,
+					final PythonVersion pythonVersion, final PythonKernelTestResult testResult) {
+				resizeRunnable.run();
+			}
+		});
+
+		// Trigger installation test if the Conda directory path changes
+		CondaPreferences.addPropertyChangeListener(m_condaDirPropertyChangeListener);
+
+		// Trigger initial installation test.
+		m_configObserver.testCurrentPreferences();
+	}
+
+}

--- a/se.redfield.bert/src/se/redfield/bert/prefs/StringPythonConfig.java
+++ b/se.redfield.bert/src/se/redfield/bert/prefs/StringPythonConfig.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2021 Redfield AB.
+*/
+package se.redfield.bert.prefs;
+
+import org.knime.core.node.defaultnodesettings.SettingsModelString;
+import org.knime.python2.config.PythonConfig;
+import org.knime.python2.config.PythonConfigStorage;
+
+final class StringPythonConfig implements PythonConfig {
+	
+	private final SettingsModelString m_model;
+	
+	StringPythonConfig(final String configKey, final String defaultValue) {
+		m_model = new SettingsModelString(configKey, defaultValue);
+	}
+
+	String getValue() {
+		return m_model.getStringValue();
+	}
+	
+	SettingsModelString getModel() {
+		return m_model;
+	}
+	
+	@Override
+	public void saveConfigTo(PythonConfigStorage storage) {
+		storage.saveStringModel(m_model);
+	}
+
+	@Override
+	public void loadConfigFrom(PythonConfigStorage storage) {
+		storage.loadStringModel(m_model);
+	}
+
+}

--- a/se.redfield.bert/src/se/redfield/bert/setting/PythonNodeSettings.java
+++ b/se.redfield.bert/src/se/redfield/bert/setting/PythonNodeSettings.java
@@ -21,7 +21,7 @@ import org.knime.core.node.NodeSettingsRO;
 import org.knime.core.node.NodeSettingsWO;
 import org.knime.python2.PythonVersion;
 import org.knime.python2.config.PythonCommandConfig;
-import org.knime.python2.prefs.PythonPreferences;
+import se.redfield.bert.prefs.BertPreferences;
 
 public class PythonNodeSettings {
 
@@ -30,11 +30,10 @@ public class PythonNodeSettings {
 	private final PythonCommandConfig pythonCommand;
 
 	public PythonNodeSettings() {
-		// TODO use bundled environment or environment coming from the extension's preference page
 		pythonCommand = new PythonCommandConfig(KEY_PYTHON_COMMAND, PythonVersion.PYTHON3,
-				CondaPreferences::getCondaInstallationDirectory, PythonPreferences::getPython3CommandPreference);
+				CondaPreferences::getCondaInstallationDirectory, BertPreferences::getPythonCommandPreference);
 	}
-
+	
 	public PythonCommandConfig getPythonCommand() {
 		return pythonCommand;
 	}

--- a/se.redfield.bert/src/se/redfield/bert/setting/model/BertModelSelectorSettings.java
+++ b/se.redfield.bert/src/se/redfield/bert/setting/model/BertModelSelectorSettings.java
@@ -28,6 +28,7 @@ import se.redfield.bert.nodes.port.BertModelFeature;
 import se.redfield.bert.nodes.port.BertModelType;
 import se.redfield.bert.nodes.selector.BertModelSelectorNodeModel;
 import se.redfield.bert.setting.PythonNodeSettings;
+import se.redfield.bert.prefs.BertPreferences;
 
 /**
  * Settings for the {@link BertModelSelectorNodeModel} node.
@@ -61,7 +62,7 @@ public class BertModelSelectorSettings extends PythonNodeSettings {
 		hfModel = new SettingsModelString(KEY_HUGGING_FACE_MODEL, "");
 		remoteUrl = new SettingsModelString(KEY_REMOTE_URL, "");
 		localPath = new SettingsModelString(KEY_LOCAL_PATH, "");
-		cacheDir = new SettingsModelString(KEY_CACHE_DIR, "");
+		cacheDir = new SettingsModelString(KEY_CACHE_DIR, BertPreferences.getCacheDir());
 		advancedModeEnabled = new SettingsModelBoolean(KEY_ADVANCED_MODE_ENABLED, false);
 	}
 


### PR DESCRIPTION
This PR adds

- Configs to create a bundled environment during the build process, that is installed alongside the extension so that users don't have to deal with Python environments to use the extension.
- A preference page for the extension that allows
   - Selection of an environment (bundled, conda or manual similar to the KNIME Python preference pages)
   - Creation of a Conda environment for CPU (all OS) and GPU (Windows and Linux)
   - Specification of a cache directory