### PR TITLE
Adapt to changes in Python kernel backend

### DIFF
--- a/se.redfield.bert/py/BertClassifier.py
+++ b/se.redfield.bert/py/BertClassifier.py
@@ -2,7 +2,7 @@ import tempfile
 import tensorflow as tf
 import numpy as np
 import pandas as pd
-import knime_io as knio
+import knime.scripting.io as knio
 from transformers import TFAutoModel
 
 from BertEmbedder import BertEmbedder
@@ -73,7 +73,7 @@ class BertClassifier:
     
     @classmethod
     def run_train(cls,
-        input_table: knio.ReadTable,
+        input_table: knio.Table,
         bert_model_type_key,
         bert_model_handle,
         sentence_column,
@@ -103,11 +103,11 @@ class BertClassifier:
         classifier.save(file_store)
 
         output_table = pd.DataFrame(progress_logger.logs)
-        knio.output_tables[0] = knio.write_table(output_table)
+        knio.output_tables[0] = knio.Table.from_pandas(output_table)
 
     @classmethod
     def run_predict(cls,
-        input_table: knio.ReadTable,
+        input_table: knio.Table,
         sentence_column,
         file_store,
         bert_model_type_key,
@@ -119,7 +119,7 @@ class BertClassifier:
         tokenizer = model_type.tokenizer_cls.from_saved_model(model, sentence_column, max_seq_length=max_seq_length)
         classifier = BertClassifier(tokenizer=tokenizer, model=model)
 
-        write_table = knio.batch_write_table()
+        write_table = knio.BatchOutputTable.create()
         progress_done = 0
         for batch in input_table.batches():
             pd_batch = batch.to_pandas() # TODO pyarrow is probably more efficient

--- a/se.redfield.bert/py/BertEmbedder.py
+++ b/se.redfield.bert/py/BertEmbedder.py
@@ -1,6 +1,6 @@
 import tensorflow as tf
 import pandas as pd
-import knime_io as knio
+import knime.scripting.io as knio
 from tensorflow.keras.models import Model
 
 from ProgressCallback import ProgressCallback
@@ -52,7 +52,7 @@ class BertEmbedder:
 
     @classmethod
     def run_from_pretrained(cls,
-        input_table:knio.ReadTable,
+        input_table:knio.Table,
         bert_model_type_key,
         bert_model_handle,
         sentence_column,
@@ -66,7 +66,7 @@ class BertEmbedder:
     ):
         model_type = BertModelType.from_key(bert_model_type_key)
         embedder = cls.from_pretrained(model_type, bert_model_handle, sentence_column, second_sentence_column, max_seq_length, cache_dir)
-        write_table = knio.batch_write_table()
+        write_table = knio.BatchOutputTable.create()
         progress_done = 0
         for batch in input_table.batches():
             pd_batch = batch.to_pandas()
@@ -93,7 +93,7 @@ class BertEmbedder:
         saved_model = tf.keras.models.load_model(file_store)
         model_type = BertModelType.from_key(bert_model_type_key)
         embedder = cls.from_saved_model(model_type, saved_model, sentence_column, second_sentence_column, max_seq_length)
-        write_table = knio.batch_write_table()
+        write_table = knio.BatchOutputTable.create()
         progress_done = 0
         for batch in input_table.batches():
             pd_batch = batch.to_pandas()

--- a/se.redfield.bert/py/ZeroShotTextClassifier.py
+++ b/se.redfield.bert/py/ZeroShotTextClassifier.py
@@ -1,7 +1,7 @@
 import tensorflow as tf
 import pandas as pd
 import numpy as np
-import knime_io as knio
+import knime.scripting.io as knio
 from transformers import TFAutoModelForSequenceClassification, AutoTokenizer
 from ProgressCallback import ProgressCallback
 
@@ -103,4 +103,4 @@ class ZeroShotTextClassifier:
         classifier = ZeroShotTextClassifier(model, tokenizer, multi_label, hypothesis)
         output_table  = classifier.predict(input_table, sentence_column, candidate_labels, batch_size) 
 
-        knio.output_tables[0] = knio.write_table(output_table)
+        knio.output_tables[0] = knio.Table.from_pandas(output_table)

--- a/se.redfield.bert/src/se/redfield/bert/core/BertCommands.java
+++ b/se.redfield.bert/src/se/redfield/bert/core/BertCommands.java
@@ -73,7 +73,6 @@ public class BertCommands implements AutoCloseable {
 			PythonKernel kernel = PythonKernelQueue.getNextKernel(command, PythonKernelBackendType.PYTHON3,
 					Collections.emptySet(), Collections.emptySet(), options, PythonCancelable.NOT_CANCELABLE);
 			kernel.execute("import tensorflow as tf");
-			kernel.execute("import knime_io as knio");
 			kernel.execute(setupPythonPath());
 			return kernel;
 		} catch (PythonIOException e) {
@@ -124,8 +123,10 @@ public class BertCommands implements AutoCloseable {
 
 	public void executeInKernel(String code, ExecutionMonitor exec)
 			throws PythonIOException, CanceledExecutionException {
+		// must be imported after the input tables are put in so that they are wrapped properly
+		kernel.execute("import knime.scripting.io as knio");
 		progressListener.setMonitor(exec);
-		kernel.execute(code, new PythonExecutionMonitorCancelable(exec));
+		kernel.executeAndCheckOutputs(code, new PythonExecutionMonitorCancelable(exec));
 		progressListener.setMonitor(null);
 		exec.setProgress(1.0);
 	}


### PR DESCRIPTION
Adapts the code to changes in the Python kernel backend that cause the nodes to fail in AP 4.7.0.
Includes the switch to the new scripting API.