### PR TITLE
Update BERT version, dependency boundaries to knime plugins and pin t…

### DIFF
--- a/knime.yml
+++ b/knime.yml
@@ -16,8 +16,8 @@ env_yml_path:
   win-64: se.redfield.bert/config/bert_win_cpu.yml
   linux-64: se.redfield.bert/config/bert_linux_cpu.yml
   osx-64: se.redfield.bert/config/bert_osx_cpu.yml
-version: 1.0.2
-copyright: "Copyright (c) 2020 Redfield AB"
+version: 1.0.3
+copyright: "Copyright (c) 2023 Redfield AB"
 license_file: LICENSE.txt
 java_bundles:
   - se.redfield.bert

--- a/se.redfield.bert/META-INF/MANIFEST.MF
+++ b/se.redfield.bert/META-INF/MANIFEST.MF
@@ -2,23 +2,23 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: BERT extension for KNIME Workbench
 Bundle-SymbolicName: se.redfield.bert; singleton:=true
-Bundle-Version: 1.0.2.qualifier
+Bundle-Version: 1.0.3.qualifier
 Bundle-ClassPath: bert.jar
 Bundle-Activator: se.redfield.bert.BertPlugin
 Bundle-Vendor: Redfield AB
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.13.0,4.0.0)",
- org.knime.workbench.core;bundle-version="[4.4.1,5.0.0)",
- org.knime.workbench.repository;bundle-version="[4.4.0,5.0.0)",
- org.knime.base;bundle-version="[4.4.1,5.0.0)",
- org.knime.python2;bundle-version="[4.4.1,5.0.0)",
- org.knime.dl;bundle-version="[4.4.1,5.0.0)",
+ org.knime.workbench.core;bundle-version="[5.1.0,6.0.0)",
+ org.knime.workbench.repository;bundle-version="[5.1.0,6.0.0)",
+ org.knime.base;bundle-version="[5.1.0,6.0.0)",
+ org.knime.python2;bundle-version="[5.1.0,6.0.0)",
+ org.knime.dl;bundle-version="[5.1.0,6.0.0)",
  com.google.guava;bundle-version="[19.0.0,20.0.0)",
- org.knime.python3;bundle-version="[4.6.0,5.0.0)",
- org.knime.python3.scripting;bundle-version="[4.6.0,5.0.0)",
- org.knime.dl.python;bundle-version="[4.6.0,5.0.0)",
- org.knime.ext.textprocessing;bundle-version="[4.6.0,5.0.0)",
- org.knime.conda;bundle-version="[4.6.0,5.0.0)",
- org.knime.python3.scripting.nodes;bundle-version="[4.6.0,5.0.0)",
+ org.knime.python3;bundle-version="[5.1.0,6.0.0)",
+ org.knime.python3.scripting;bundle-version="[5.1.0,6.0.0)",
+ org.knime.dl.python;bundle-version="[5.1.0,6.0.0)",
+ org.knime.ext.textprocessing;bundle-version="[5.1.0,6.0.0)",
+ org.knime.conda;bundle-version="[5.1.0,6.0.0)",
+ org.knime.python3.scripting.nodes;bundle-version="[5.1.0,6.0.0)",
  com.google.gson;bundle-version="[2.8.6,3.0.0)"
 Bundle-ActivationPolicy: lazy
 Export-Package: se.redfield.bert

--- a/se.redfield.bert/config/bert_win_cpu.yml
+++ b/se.redfield.bert/config/bert_win_cpu.yml
@@ -14,6 +14,7 @@ dependencies:            # List of packages that should be installed
 - pip
 - pip:
   - tensorflow==2.9.1
+  - tensorflow-io-gcs-filesystem==0.31.0
   - tensorflow-hub==0.12.0
   - transformers==4.21.1
   - bert-for-tf2==0.14.9


### PR DESCRIPTION
…ensor-flow-io-gcs-filesytem.

tensor-flow-io-gcs-filesytem is available for 0.33.0, but only for MacOS and Linus. Windows has only 0.31.0 available.