### PR TITLE
Revert "Import bundled env pref classes from org.knime.python2"

### DIFF
--- a/se.redfield.bert/META-INF/MANIFEST.MF
+++ b/se.redfield.bert/META-INF/MANIFEST.MF
@@ -18,6 +18,7 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.13.0,4.0.0)",
  org.knime.dl.python;bundle-version="[5.1.0,6.0.0)",
  org.knime.ext.textprocessing;bundle-version="[5.1.0,6.0.0)",
  org.knime.conda;bundle-version="[5.1.0,6.0.0)",
+ org.knime.python3.scripting.nodes;bundle-version="[5.1.0,6.0.0)",
  com.google.gson;bundle-version="[2.8.6,3.0.0)"
 Bundle-ActivationPolicy: lazy
 Export-Package: se.redfield.bert

--- a/se.redfield.bert/src/se/redfield/bert/prefs/BertPreferencePage.java
+++ b/se.redfield.bert/src/se/redfield/bert/prefs/BertPreferencePage.java
@@ -10,10 +10,10 @@ import org.eclipse.core.runtime.Platform;
 import org.eclipse.swt.widgets.Composite;
 import org.knime.core.util.Version;
 import org.knime.python2.PythonModuleSpec;
-import org.knime.python2.config.BundledCondaEnvironmentConfig;
 import org.knime.python2.config.PythonConfig;
 import org.knime.python2.prefs.AbstractPythonPreferencePage;
 import org.knime.python3.PythonSourceDirectoryLocator;
+import org.knime.python3.scripting.nodes.prefs.BundledCondaEnvironmentConfig;
 
 import se.redfield.bert.prefs.MultiOptionEnvironmentCreator.CondaEnvironmentCreationOption;
 

--- a/se.redfield.bert/src/se/redfield/bert/prefs/BertPreferences.java
+++ b/se.redfield.bert/src/se/redfield/bert/prefs/BertPreferences.java
@@ -13,7 +13,6 @@ import org.eclipse.core.runtime.preferences.DefaultScope;
 import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.knime.core.node.NodeLogger;
 import org.knime.python2.PythonCommand;
-import org.knime.python2.config.BundledCondaEnvironmentConfig;
 import org.knime.python2.config.CondaEnvironmentsConfig;
 import org.knime.python2.config.ManualEnvironmentsConfig;
 import org.knime.python2.config.PythonConfig;
@@ -23,6 +22,7 @@ import org.knime.python2.config.PythonEnvironmentTypeConfig;
 import org.knime.python2.config.PythonEnvironmentsConfig;
 import org.knime.python2.prefs.PreferenceStorage;
 import org.knime.python2.prefs.PreferenceWrappingConfigStorage;
+import org.knime.python3.scripting.nodes.prefs.BundledCondaEnvironmentConfig;
 
 /**
  * Convenience front-end of the BERT preferences.

--- a/se.redfield.bert/src/se/redfield/bert/prefs/BundledEnvironmentConfigsObserver.java
+++ b/se.redfield.bert/src/se/redfield/bert/prefs/BundledEnvironmentConfigsObserver.java
@@ -61,15 +61,12 @@ import org.knime.conda.prefs.CondaPreferences;
 import org.knime.core.node.defaultnodesettings.SettingsModelString;
 import org.knime.python2.PythonCommand;
 import org.knime.python2.PythonKernelTester;
-import org.knime.python2.PythonKernelTester.PythonKernelTestResult;
 import org.knime.python2.PythonModuleSpec;
 import org.knime.python2.PythonVersion;
+import org.knime.python2.PythonKernelTester.PythonKernelTestResult;
 import org.knime.python2.config.AbstractCondaEnvironmentCreationObserver;
-import org.knime.python2.config.AbstractCondaEnvironmentCreationObserver.CondaEnvironmentCreationStatus;
-import org.knime.python2.config.AbstractCondaEnvironmentCreationObserver.CondaEnvironmentCreationStatusListener;
 import org.knime.python2.config.AbstractCondaEnvironmentsPanel;
 import org.knime.python2.config.AbstractPythonConfigsObserver;
-import org.knime.python2.config.BundledCondaEnvironmentConfig;
 import org.knime.python2.config.CondaEnvironmentConfig;
 import org.knime.python2.config.CondaEnvironmentsConfig;
 import org.knime.python2.config.ManualEnvironmentConfig;
@@ -80,6 +77,9 @@ import org.knime.python2.config.PythonEnvironmentType;
 import org.knime.python2.config.PythonEnvironmentTypeConfig;
 import org.knime.python2.config.PythonEnvironmentsConfig;
 import org.knime.python2.config.SerializerConfig;
+import org.knime.python2.config.AbstractCondaEnvironmentCreationObserver.CondaEnvironmentCreationStatus;
+import org.knime.python2.config.AbstractCondaEnvironmentCreationObserver.CondaEnvironmentCreationStatusListener;
+import org.knime.python3.scripting.nodes.prefs.BundledCondaEnvironmentConfig;
 
 /**
  * Specialization of the {@link PythonConfigsObserver} for nodes that come with

--- a/se.redfield.bert/src/se/redfield/bert/prefs/PythonEnvironmentSelectionConfig.java
+++ b/se.redfield.bert/src/se/redfield/bert/prefs/PythonEnvironmentSelectionConfig.java
@@ -5,12 +5,12 @@ package se.redfield.bert.prefs;
 
 import java.util.List;
 
-import org.knime.python2.config.BundledCondaEnvironmentConfig;
 import org.knime.python2.config.CondaEnvironmentsConfig;
 import org.knime.python2.config.ManualEnvironmentsConfig;
 import org.knime.python2.config.PythonConfig;
 import org.knime.python2.config.PythonConfigStorage;
 import org.knime.python2.config.PythonEnvironmentTypeConfig;
+import org.knime.python3.scripting.nodes.prefs.BundledCondaEnvironmentConfig;
 
 final class PythonEnvironmentSelectionConfig implements PythonConfig {
 

--- a/se.redfield.bert/src/se/redfield/bert/prefs/PythonEnvironmentSelectionPanel.java
+++ b/se.redfield.bert/src/se/redfield/bert/prefs/PythonEnvironmentSelectionPanel.java
@@ -12,12 +12,12 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Label;
 import org.knime.conda.prefs.CondaPreferences;
-import org.knime.python2.PythonKernelTester.PythonKernelTestResult;
 import org.knime.python2.PythonVersion;
-import org.knime.python2.config.AbstractPythonConfigsObserver.PythonConfigsInstallationTestStatusChangeListener;
+import org.knime.python2.PythonKernelTester.PythonKernelTestResult;
 import org.knime.python2.config.PythonEnvironmentType;
+import org.knime.python2.config.AbstractPythonConfigsObserver.PythonConfigsInstallationTestStatusChangeListener;
 import org.knime.python2.prefs.ManualEnvironmentsPreferencePanel;
-import org.knime.python2.prefs.PythonBundledEnvironmentTypePreferencePanel;
+import org.knime.python3.scripting.nodes.prefs.PythonBundledEnvironmentTypePreferencePanel;
 
 final class PythonEnvironmentSelectionPanel {
 


### PR DESCRIPTION
Necessary because in 5.1 this is not used.

This reverts commit 5d1a748918e79f36675e1d49154e7766a4518ab8.